### PR TITLE
feat(thread): add faulting field to thread struct

### DIFF
--- a/threads.go
+++ b/threads.go
@@ -8,6 +8,7 @@ import (
 
 type Thread struct {
 	Name   string       `json:"name"`
+	Fault  bool         `json:"fault"`
 	Stacks []StackFrame `json:"stack"`
 }
 
@@ -41,7 +42,7 @@ func ParseThreadsFromStack(stackTrace []byte) (map[string]Thread, map[string]Sou
 		lines := strings.Split(stackText, "\n")
 
 		sf := StackFrame{}
-		thread := Thread{Name: strings.TrimSuffix(lines[0], ":")}
+		thread := Thread{Name: strings.TrimSuffix(lines[0], ":"), Fault: threadID == 0}
 		for i := 1; i < len(lines); i++ {
 			line := strings.TrimSpace(lines[i])
 			if line == "" {

--- a/threads_test.go
+++ b/threads_test.go
@@ -56,7 +56,8 @@ func TestParseThreadsFromStack(t *testing.T) {
 			},
 			wantThreads: map[string]Thread{
 				"0": {
-					Name: "goroutine 1 [running]",
+					Name:  "goroutine 1 [running]",
+					Fault: true,
 					Stacks: []StackFrame{
 						{
 							FuncName:     "GetStack",


### PR DESCRIPTION
The faulting thread in the stack trace algorithm should set a “faultingThread” boolean variable. This variable allows to indicate which one thread is causing the issue - also behind the scene, this thread will be used to generate a fingerprint and error description. 