### PR TITLE
feat(attributes): add default attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/backtrace-labs/backtrace-go
 go 1.22
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.25.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/main_test.go
+++ b/main_test.go
@@ -103,4 +103,11 @@ func causeErrorReport() {
 	go doSomething(make(chan int))
 	Report(errors.New("it broke"), nil)
 	finishSendingReports(false)
+
+	for _, v := range []string{"backtrace.version", "backtrace.agent", "hostname", "uname.sysname", "cpu.arch", "process.id", "application.session", "application"} {
+		if _, ok := Options.Attributes[v]; !ok {
+			panic(v + " - attribute not set")
+		}
+	}
+
 }


### PR DESCRIPTION
Add fields:
    

    application.session: an uuid that will be the same for all reports in single application session. 
    
    guid: unique machine identifier 

    uname.sysname - name of the operating system

    backtrace.agent - name of the go library (this is a constant value set to backtrace-go)

    backtrace.version - version of the go library 

    uname.version - version of the operating system

    hostname - current hostname

    cpu.arch - CPU arch

    cpu.brand - CPU brand

    application - current application name 

    process.id  - current process id
