### PR TITLE
Improvements/prod hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,22 +13,27 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.26.x'
       - name: Check gofmt
         run: |
           unformatted="$(gofmt -l .)"
           if [ -n "$unformatted" ]; then
             echo "gofmt required for:"; echo "$unformatted"; exit 1
           fi
+      - name: Verify go.mod/go.sum are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.12.2
 
   test:
     name: test (go ${{ matrix.go-version }}, ${{ matrix.os }})
@@ -40,6 +45,7 @@ jobs:
         go-version: ['1.25.x', '1.26.x']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -51,9 +57,41 @@ jobs:
       - name: Run unit tests (race detector)
         run: go test -race -count=1 ./...
 
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+      - name: Scan for known vulnerabilities
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          govulncheck ./...
+
+  fuzz-smoke:
+    name: fuzz (smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+      - name: Fuzz parsers and redaction briefly
+        run: |
+          for target in FuzzBuildThreads FuzzRedactURL FuzzRetryAfter FuzzSplitQualifiedFunction FuzzSafeMultipartName; do
+            go test -run "^$target$" -fuzz "^$target$" -fuzztime 20s .
+          done
+
   cross-compile:
     name: build (${{ matrix.target }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +107,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.26.x'
       - name: Build
         run: |
           export GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}"

--- a/README.md
+++ b/README.md
@@ -55,18 +55,22 @@ client.ReportMessage("cache warmup skipped", nil) // plain message
 client.ReportPanicValue(recovered, nil)           // recovered panic value
 
 // Panic capture with defer:
-defer bt.ReportPanic(nil)           // reports, flushes, re-panics
-defer bt.ReportAndRecoverPanic(nil) // reports and swallows the panic
+defer bt.ReportPanic(nil)           // reports, waits (one 5s deadline), re-panics
+defer bt.ReportAndRecoverPanic(nil) // reports without waiting; swallows the panic
 ```
 
-Reporting never blocks the caller on network I/O: reports are queued to a background worker, and when the queue is full new reports are dropped and counted (`client.DroppedReports()`) instead of stalling the application.
+Regular `Report*` calls never block on network I/O or queue admission: reports are queued to a background worker, and a full queue drops the newest report and counts it (`client.Stats()`, `client.DroppedReports()`) instead of stalling the application. The only synchronous waits are the explicitly bounded ones: `Flush`, `Close`, `ReportPanicValueAndFlush`, and `bt.ReportPanic` (one 5s deadline); `ReportAndRecoverPanic` reports without waiting.
 
 Delivery lifecycle:
 
 ```go
-client.Flush(5 * time.Second) // wait for queued reports; client stays usable
-client.Close()                // drain, stop the worker, release the client
+client.Flush(5 * time.Second)  // wait for reports queued before the call; client stays usable
+client.FlushContext(ctx)       // context-aware variant
+client.Close()                 // drain and stop, bounded by ShutdownTimeout (default 5s)
+client.CloseContext(ctx)       // explicit deadline; cancels in-flight sends when it expires
 ```
+
+Flushing proves local processing and send completion, not backend acceptance. While the SDK is unconfigured, `bt.ReportPanic`/`bt.ReportAndRecoverPanic` do nothing — in particular they do not recover, so the application's panic proceeds unchanged.
 
 ## Configuration
 
@@ -74,7 +78,8 @@ client.Close()                // drain, stop the worker, release the client
 client, err := bt.NewClient(bt.Config{
 	Endpoint:             "https://submit.backtrace.io/{universe}/{token}/json",
 	CaptureAllGoroutines: true,                 // include every goroutine's stack
-	SourceCode:           bt.SourceCodeContext, // context lines (default), File, or None
+	SourceCode:           bt.SourceCodeContext, // default: Metadata (no source text); Context/File are opt-in
+	SourceRoots:          []string{"/srv/app"}, // restrict which files may be read for snippets
 	ContextLineCount:     8,                    // lines above/below each frame
 	Attributes: map[string]interface{}{         // stamped on every report
 		"application.environment": "production",
@@ -102,7 +107,7 @@ client.AddBreadcrumb(bt.Breadcrumb{
 })
 ```
 
-Every report automatically includes: hostname, process ID and age, Go version, goroutine count, heap statistics, GC count, CPU architecture and model, OS version, machine GUID, `application.version` / `vcs.revision` (from Go build info), the Go module dependency list, and — on Linux — `/proc` memory and scheduler attributes.
+Every report automatically includes: hostname, process ID and age, Go version, goroutine count, heap statistics, GC count, CPU architecture and model, OS version, `application.version` / `vcs.revision` (from Go build info), the Go module dependency list, and — on Linux — `/proc` memory and scheduler attributes. A stable machine identifier (`guid`) is opt-in via `SendMachineID`. Machine metadata is gathered once per process with native file, syscall, and registry reads — no shell pipelines (macOS additionally runs a single time-bounded `ioreg` probe for the opt-in machine identifier).
 
 ### net/http middleware
 
@@ -112,13 +117,18 @@ import "github.com/backtrace-labs/backtrace-go/bthttp"
 handler := bthttp.New(bthttp.Options{
 	Client:          client, // omit to use the global reporter
 	Repanic:         false,  // re-raise after reporting
-	WaitForDelivery: true,   // block the failing request until delivered
+	WaitForDelivery: true,   // block the failing request until delivered (bounded by FlushTimeout)
+	SendDefaultPII:  false,  // raw path/host/remote addr/user agent are OPT-IN
 })
 http.ListenAndServe(":8080", handler.Handle(mux))
 ```
 
-Panics in handlers are reported with `request.url`, `request.method`,
-`request.remote_addr`, and `request.user_agent` attributes.
+By default panic reports carry `request.method`, `request.proto`, and the
+registered route pattern (`request.route`). Raw URL path, host, remote
+address, and user agent require `SendDefaultPII: true`; use
+`RequestAttributes` to contribute application-approved metadata. When a
+swallowed panic left the response uncommitted, the middleware writes
+`500 Internal Server Error` instead of an empty `200`.
 
 ## Legacy global API
 
@@ -142,7 +152,7 @@ Notes:
 
 - Configure `bt.Options` before the first report. For attribute changes at runtime use `bt.SetAttribute` / `bt.SetAttributes`, which are safe for concurrent use.
 - `bt.FinishSendingReports()` now waits for queued reports **without** stopping the reporter (historically it killed the sender permanently): prefer `bt.Flush(timeout)`.
-- Source capture now defaults to context lines around each frame instead of whole files: opt back in with `Options.SourceCode = bt.SourceCodeFile`.
+- Source capture now defaults to path/line metadata only — no source text leaves the host. Opt in with `Options.SourceCode = bt.SourceCodeContext` (snippets) or `bt.SourceCodeFile` (whole files), optionally constrained by `Options.SourceRoots`.
 - The reporting API (`Client` methods, `bt.Report`, `bt.ReportPanic`, ...) never panics; `DebugBacktrace` only controls diagnostic logging. (The bcd tracing integration may panic on tracer kill failure unless `GlobalConfig.PanicOnKillFailure` is disabled via `bt.UpdateConfig`.)
 
 ## Thread-safety contract
@@ -151,6 +161,19 @@ Notes:
 `AddBreadcrumb`, `Flush`, and `Close` are safe for concurrent use. The
 `Options` struct and `Config` maps are read when reports are captured;
 mutate them only before reporting starts (or via `SetAttribute`).
+
+## Migration and security
+
+- [MIGRATION.md](MIGRATION.md) — upgrading from pre-1.1.0 (Go floor, source
+  capture opt-in, panic-helper semantics, shutdown behavior).
+- [SECURITY.md](SECURITY.md) — private vulnerability reporting.
+
+## Scope
+
+This SDK reports errors, messages, and recovered panics from within the
+process. Crashes that bypass Go panics (native/cgo faults, runtime aborts)
+require out-of-process capture: use the bcd tracer integration below, or
+the Backtrace Coresnap workflow, for robust fatal-crash coverage.
 
 ## bcd (out-of-process tracing)
 

--- a/attributes.go
+++ b/attributes.go
@@ -1,9 +1,8 @@
 package bt
 
 import (
-	"context"
+	neturl "net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -11,27 +10,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-)
-
-// execCommandTimeout bounds every machine-metadata subprocess.
-const execCommandTimeout = 2 * time.Second
-
-var (
-	windowsGUIDCommand = []string{"reg", "query", `HKEY_LOCAL_MACHINE\Software\Microsoft\Cryptography`, "/v", "MachineGuid"}
-	linuxGUIDCommand   = []string{"sh", "-c", "( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :"}
-	freebsdGUIDCommand = []string{"sh", "-c", "kenv -q smbios.system.uuid || sysctl -n kern.hostuuid"}
-	darwinGUIDCommand  = []string{"sh", "-c", "ioreg -rd1 -c IOPlatformExpertDevice | grep IOPlatformUUID | awk -F'= \"' '{print $2}' | tr -d '\"' | tr -d '\n'"}
-
-	// reg query instead of wmic: wmic is removed from Windows 11 24H2 /
-	// Server 2025.
-	windowsCPUCommand = []string{"reg", "query", `HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\CentralProcessor\0`, "/v", "ProcessorNameString"}
-	linuxCPUCommand   = []string{"sh", "-c", "lscpu | grep \"Model name\" | awk -F':' '{print $2}' | sed 's/^[[:space:]]*//'"}
-	darwinCPUCommand  = []string{"sh", "-c", "sysctl -n machdep.cpu.brand_string | tr -d '\n'"}
-	freebsdCPUCommand = []string{"sh", "-c", "sysctl -n hw.model"}
-
-	linuxOSVersionCommand   = []string{"sh", "-c", "cat /etc/os-release | grep VERSION= | awk -F'=\"' '{print $2}' | tr -d '\"'"}
-	darwinOSVersionCommand  = []string{"sh", "-c", "sw_vers | grep ProductVersion | awk -F':' '{print $2}' | tr -d '\t' | tr -d '\n'"}
-	freebsdOSVersionCommand = []string{"sh", "-c", "cat /etc/os-release | grep VERSION= | awk -F'=\"' '{print $2}' | tr -d '\"'"}
 )
 
 // processSessionID identifies this process instance across its reports.
@@ -87,87 +65,32 @@ func runtimeAttributes(attrs map[string]interface{}) {
 var (
 	machineOnce  sync.Once
 	machineAttrs map[string]interface{}
+
+	machineGUIDOnce sync.Once
+	machineGUIDVal  string
 )
 
-// machineAttributes gathers machine metadata (GUID, CPU model, OS version)
-// by shelling out to platform tools. It runs at most once per process, on
-// first use — never at import time — and each command is bounded by
-// execCommandTimeout. Failures degrade to missing attributes.
+// machineAttributes gathers machine metadata (CPU model, OS version) using
+// native file and syscall reads — never shell pipelines. It runs at most
+// once per process, on first use (never at import time). Failures degrade
+// to missing attributes.
 func machineAttributes(d diag) map[string]interface{} {
 	machineOnce.Do(func() {
 		attrs := map[string]interface{}{}
-
-		var guidCommand, cpuCommand, osCommand []string
-		switch runtime.GOOS {
-		case "windows":
-			guidCommand = windowsGUIDCommand
-			cpuCommand = windowsCPUCommand
-		case "linux":
-			guidCommand = linuxGUIDCommand
-			cpuCommand = linuxCPUCommand
-			osCommand = linuxOSVersionCommand
-		case "darwin":
-			guidCommand = darwinGUIDCommand
-			cpuCommand = darwinCPUCommand
-			osCommand = darwinOSVersionCommand
-		case "freebsd":
-			guidCommand = freebsdGUIDCommand
-			cpuCommand = freebsdCPUCommand
-			osCommand = freebsdOSVersionCommand
-		}
-
-		if output := execCommand(guidCommand, d); output != "" {
-			if runtime.GOOS == "windows" {
-				output = strings.Trim(parseWindowsRegValue(output), "{}")
-			}
-			attrs["guid"] = strings.TrimSpace(output)
-		}
-
-		if output := execCommand(cpuCommand, d); output != "" {
-			if runtime.GOOS == "windows" {
-				output = parseWindowsRegValue(output)
-			}
-			attrs["cpu.brand"] = strings.TrimSpace(output)
-		}
-
-		if output := execCommand(osCommand, d); output != "" {
-			attrs["uname.version"] = strings.TrimSpace(output)
-		}
-
+		collectMachineInfo(attrs, d)
 		machineAttrs = attrs
 	})
 	return machineAttrs
 }
 
-// parseWindowsRegValue extracts the value from `reg query` output:
-//
-//	HKEY_LOCAL_MACHINE\...
-//	    ValueName    REG_SZ    the value, possibly with spaces
-func parseWindowsRegValue(output string) string {
-	if idx := strings.Index(output, "REG_SZ"); idx >= 0 {
-		value := output[idx+len("REG_SZ"):]
-		// Keep only the first line after the type column.
-		value, _, _ = strings.Cut(strings.TrimLeft(value, " \t"), "\r")
-		value, _, _ = strings.Cut(value, "\n")
-		return strings.TrimSpace(value)
-	}
-	return strings.TrimSpace(output)
-}
-
-// execCommand runs command[0] with the remaining arguments and returns its
-// stdout, or "" on any failure. A nil/empty command returns "".
-func execCommand(command []string, d diag) string {
-	if len(command) == 0 {
-		return ""
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), execCommandTimeout)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, command[0], command[1:]...).Output()
-	if err != nil {
-		d.logf("machine attribute command %q failed: %v", command[0], err)
-		return ""
-	}
-	return string(out)
+// machineGUID resolves the stable machine identifier lazily and only when a
+// client actually opted in via SendMachineID — on macOS this is the one
+// probe that spawns a (bounded, non-shell) subprocess.
+func machineGUID(d diag) string {
+	machineGUIDOnce.Do(func() {
+		machineGUIDVal = collectMachineGUID(d)
+	})
+	return machineGUIDVal
 }
 
 var (
@@ -176,9 +99,12 @@ var (
 	buildInfoModules []string
 )
 
+// maxDependencyModules caps the dependency annotation size.
+const maxDependencyModules = 512
+
 // buildInfoAttributes extracts release metadata embedded by the Go toolchain:
 // main module version, VCS revision/time/dirty flag, and the dependency list
-// (attached to reports as the "Dependencies" annotation).
+// (attached to reports as the "Dependencies" annotation, capped).
 func buildInfoAttributes() (map[string]interface{}, []string) {
 	buildInfoOnce.Do(func() {
 		attrs := map[string]interface{}{}
@@ -200,8 +126,12 @@ func buildInfoAttributes() (map[string]interface{}, []string) {
 				attrs["vcs.modified"] = s.Value
 			}
 		}
-		modules := make([]string, 0, len(info.Deps))
-		for _, dep := range info.Deps {
+		deps := info.Deps
+		if len(deps) > maxDependencyModules {
+			deps = deps[:maxDependencyModules]
+		}
+		modules := make([]string, 0, len(deps))
+		for _, dep := range deps {
 			m := dep
 			if m.Replace != nil {
 				m = m.Replace
@@ -256,7 +186,30 @@ func getEnvVars(extraPatterns []string) map[string]string {
 		if value != redactedValue && urlUserinfoPattern.MatchString(value) {
 			value = redactedValue
 		}
+		// Submission-URL shapes (the SDK's own BACKTRACE_ENDPOINT, or any
+		// variable holding a tokenized submit URL) get their token
+		// redacted while keeping the rest of the URL readable.
+		if value != redactedValue {
+			value = redactSubmissionValue(value)
+		}
 		result[key] = value
 	}
 	return result
+}
+
+// redactSubmissionValue redacts embedded Backtrace submission tokens
+// (?token= query or submit-style path) in URL-shaped env values.
+func redactSubmissionValue(value string) string {
+	if !strings.HasPrefix(value, "http://") && !strings.HasPrefix(value, "https://") {
+		return value
+	}
+	u, err := neturl.Parse(value)
+	if err != nil {
+		return value
+	}
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if u.Query().Get("token") != "" || pathEmbedsToken(u.Hostname(), segments) {
+		return redactURL(value)
+	}
+	return value
 }

--- a/attributes_darwin.go
+++ b/attributes_darwin.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package bt
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// machineInfoBudget bounds the one-time ioreg probe.
+const machineInfoBudget = time.Second
+
+// collectMachineInfo gathers macOS machine metadata via sysctl — native
+// syscalls only, no subprocesses.
+func collectMachineInfo(attrs map[string]interface{}, d diag) {
+	if v, err := unix.Sysctl("machdep.cpu.brand_string"); err == nil && v != "" {
+		attrs["cpu.brand"] = v
+	}
+	if v, err := unix.Sysctl("kern.osproductversion"); err == nil && v != "" {
+		attrs["uname.version"] = v
+	}
+}
+
+// collectMachineGUID resolves the platform UUID (opt-in via
+// Config.SendMachineID). This is the only machine probe that spawns a
+// subprocess — one bounded ioreg invocation with arguments, never a shell
+// pipeline — and it runs only after a client opts in.
+func collectMachineGUID(d diag) string {
+	ctx, cancel := context.WithTimeout(context.Background(), machineInfoBudget)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+	if err != nil {
+		d.logf("machine identifier probe (ioreg) failed: %v", err)
+		return ""
+	}
+	return parseIOPlatformUUID(string(out))
+}
+
+// parseIOPlatformUUID extracts the quoted IOPlatformUUID value from ioreg
+// output ("IOPlatformUUID" = "XXXX-...").
+func parseIOPlatformUUID(output string) string {
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.Contains(line, "IOPlatformUUID") {
+			continue
+		}
+		_, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		return strings.Trim(strings.TrimSpace(value), `"`)
+	}
+	return ""
+}

--- a/attributes_freebsd.go
+++ b/attributes_freebsd.go
@@ -1,0 +1,34 @@
+//go:build freebsd
+
+package bt
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// collectMachineInfo gathers FreeBSD machine metadata via sysctl (native
+// syscalls) and /etc/os-release — no subprocesses.
+func collectMachineInfo(attrs map[string]interface{}, d diag) {
+	if v, err := unix.Sysctl("hw.model"); err == nil && v != "" {
+		attrs["cpu.brand"] = v
+	}
+
+	if data, err := readSmallFile("/etc/os-release", 16<<10); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if k, v, ok := strings.Cut(line, "="); ok && k == "VERSION" {
+				attrs["uname.version"] = strings.Trim(strings.TrimSpace(v), `"`)
+				break
+			}
+		}
+	}
+}
+
+// collectMachineGUID resolves the host UUID (opt-in via Config.SendMachineID).
+func collectMachineGUID(d diag) string {
+	if v, err := unix.Sysctl("kern.hostuuid"); err == nil {
+		return v
+	}
+	return ""
+}

--- a/attributes_linux.go
+++ b/attributes_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package bt
+
+import "strings"
+
+// collectMachineInfo gathers Linux machine metadata from procfs and
+// standard system files — no subprocesses.
+func collectMachineInfo(attrs map[string]interface{}, d diag) {
+	if data, err := readSmallFile("/proc/cpuinfo", 64<<10); err == nil {
+		for _, line := range strings.Split(string(data), "\n") {
+			if key, value, ok := strings.Cut(line, ":"); ok &&
+				strings.TrimSpace(key) == "model name" {
+				attrs["cpu.brand"] = strings.TrimSpace(value)
+				break
+			}
+		}
+	}
+
+	if version := osReleaseValue("VERSION"); version != "" {
+		attrs["uname.version"] = version
+	}
+}
+
+// collectMachineGUID reads the stable machine identifier (opt-in via
+// Config.SendMachineID) from the standard machine-id files.
+func collectMachineGUID(d diag) string {
+	return firstExistingFileLine("/etc/machine-id", "/var/lib/dbus/machine-id")
+}
+
+// osReleaseValue extracts a key from /etc/os-release.
+func osReleaseValue(key string) string {
+	data, err := readSmallFile("/etc/os-release", 16<<10)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok && k == key {
+			return strings.Trim(strings.TrimSpace(v), `"`)
+		}
+	}
+	return ""
+}

--- a/attributes_other.go
+++ b/attributes_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin && !freebsd && !windows
+
+package bt
+
+// collectMachineInfo has no platform-specific sources here; reports carry
+// the portable attributes only.
+func collectMachineInfo(attrs map[string]interface{}, d diag) {}
+
+// collectMachineGUID has no source on this platform.
+func collectMachineGUID(d diag) string { return "" }

--- a/attributes_test.go
+++ b/attributes_test.go
@@ -59,6 +59,25 @@ func TestGetEnvVarsScrubsCommonSecretShapes(t *testing.T) {
 	}
 }
 
+// TestGetEnvVarsRedactsSubmissionURLs pins the fix for the SDK's own
+// credential: BACKTRACE_ENDPOINT (or any variable holding a tokenized
+// submission URL) must not ship its token in the env annotation.
+func TestGetEnvVarsRedactsSubmissionURLs(t *testing.T) {
+	t.Setenv("BACKTRACE_ENDPOINT", "https://submit.backtrace.io/universe/SECRETSUBMITTOKEN/json")
+	t.Setenv("BT_SHAPE_LEGACY_ENDPOINT_URL", "https://uni.sp.backtrace.io/post?format=json&token=SECRETQUERYTOKEN")
+
+	env := getEnvVars(nil)
+	if strings.Contains(env["BACKTRACE_ENDPOINT"], "SECRETSUBMITTOKEN") {
+		t.Errorf("submit-path token leaked: %q", env["BACKTRACE_ENDPOINT"])
+	}
+	if !strings.Contains(env["BACKTRACE_ENDPOINT"], "submit.backtrace.io") {
+		t.Errorf("redaction should keep the URL readable: %q", env["BACKTRACE_ENDPOINT"])
+	}
+	if strings.Contains(env["BT_SHAPE_LEGACY_ENDPOINT_URL"], "SECRETQUERYTOKEN") {
+		t.Errorf("query token leaked: %q", env["BT_SHAPE_LEGACY_ENDPOINT_URL"])
+	}
+}
+
 func TestStaticAttributes(t *testing.T) {
 	attrs := staticAttributes()
 	for _, key := range []string{
@@ -122,28 +141,15 @@ func TestBuildInfoAttributesDoesNotPanic(t *testing.T) {
 
 func TestUnwrapErrorChainTypes(t *testing.T) {
 	err := &testWrapErr{msg: "outer", inner: &testWrapErr{msg: "inner"}}
-	chain := unwrapErrorChain(err, DefaultMaxErrorDepth)
+	chain := unwrapErrorChain(err, DefaultMaxErrorDepth, DefaultMaxErrorNodes)
 	if len(chain) != 2 {
 		t.Fatalf("chain length = %d", len(chain))
 	}
 	if chain[0].Type != "*bt.testWrapErr" || chain[0].Message != "outer" {
 		t.Errorf("chain head = %+v", chain[0])
 	}
-}
-
-func TestParseWindowsRegValue(t *testing.T) {
-	guidOut := "\r\nHKEY_LOCAL_MACHINE\\Software\\Microsoft\\Cryptography\r\n" +
-		"    MachineGuid    REG_SZ    12345678-abcd-ef00-1122-334455667788\r\n\r\n"
-	if got := parseWindowsRegValue(guidOut); got != "12345678-abcd-ef00-1122-334455667788" {
-		t.Errorf("guid parse = %q", got)
-	}
-	cpuOut := "\r\nHKEY_LOCAL_MACHINE\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0\r\n" +
-		"    ProcessorNameString    REG_SZ    Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz\r\n\r\n"
-	if got := parseWindowsRegValue(cpuOut); got != "Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz" {
-		t.Errorf("cpu parse = %q (spaces must survive)", got)
-	}
-	if got := parseWindowsRegValue("no reg marker"); got != "no reg marker" {
-		t.Errorf("fallback = %q", got)
+	if chain[1].ParentID == nil || *chain[1].ParentID != 0 || chain[1].Source != "unwrap" {
+		t.Errorf("chain link parent metadata = %+v", chain[1])
 	}
 }
 

--- a/attributes_unixfiles.go
+++ b/attributes_unixfiles.go
@@ -1,0 +1,43 @@
+//go:build linux || freebsd
+
+package bt
+
+import (
+	"os"
+	"strings"
+)
+
+// firstExistingFileLine returns the first non-empty line of the first
+// readable file in paths, capped at 4 KiB.
+func firstExistingFileLine(paths ...string) string {
+	for _, p := range paths {
+		data, err := readSmallFile(p, 4096)
+		if err != nil {
+			continue
+		}
+		line, _, _ := strings.Cut(strings.TrimSpace(string(data)), "\n")
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// readSmallFile reads a regular file bounded by maxBytes.
+func readSmallFile(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, os.ErrInvalid
+	}
+	buf := make([]byte, maxBytes)
+	n, _ := f.Read(buf)
+	return buf[:n], nil
+}

--- a/attributes_windows.go
+++ b/attributes_windows.go
@@ -1,0 +1,50 @@
+//go:build windows
+
+package bt
+
+import "golang.org/x/sys/windows/registry"
+
+// collectMachineInfo gathers Windows machine metadata from the registry —
+// native API calls, no subprocesses (wmic is removed from Windows 11 24H2
+// and reg.exe is unnecessary).
+func collectMachineInfo(attrs map[string]interface{}, d diag) {
+	if v := regString(registry.LOCAL_MACHINE,
+		`HARDWARE\DESCRIPTION\System\CentralProcessor\0`, "ProcessorNameString", d); v != "" {
+		attrs["cpu.brand"] = v
+	}
+	// DisplayVersion exists on 20H2+; ReleaseId covers 1511..2004 (and is
+	// frozen at "2009" afterwards, hence the ordering).
+	version := regString(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion`, "DisplayVersion", d)
+	if version == "" {
+		version = regString(registry.LOCAL_MACHINE,
+			`SOFTWARE\Microsoft\Windows NT\CurrentVersion`, "ReleaseId", d)
+	}
+	if version != "" {
+		attrs["uname.version"] = version
+	}
+}
+
+// collectMachineGUID reads the stable machine identifier (opt-in via
+// Config.SendMachineID) from the registry.
+func collectMachineGUID(d diag) string {
+	return regString(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Cryptography`, "MachineGuid", d)
+}
+
+func regString(root registry.Key, path, name string, d diag) string {
+	// WOW64_64KEY: read the 64-bit registry view so 32-bit builds see the
+	// same MachineGuid/CPU keys as native ones.
+	key, err := registry.OpenKey(root, path, registry.QUERY_VALUE|registry.WOW64_64KEY)
+	if err != nil {
+		d.logf("machine attribute registry open %q failed: %v", path, err)
+		return ""
+	}
+	defer key.Close()
+	value, _, err := key.GetStringValue(name)
+	if err != nil {
+		d.logf("machine attribute registry read %q\\%s failed: %v", path, name, err)
+		return ""
+	}
+	return value
+}

--- a/bcd.go
+++ b/bcd.go
@@ -84,12 +84,25 @@ func init() {
 			SynchronousPut:     true}}
 }
 
-// Update global Tracer configuration.
+// Update global Tracer configuration. Negative durations are treated as
+// zero.
 func UpdateConfig(c GlobalConfig) {
+	if c.RateLimit < 0 {
+		c.RateLimit = 0
+	}
+
 	state.m.Lock()
 	defer state.m.Unlock()
 
 	state.c = c
+}
+
+// logfSafe shields lock-critical paths from panicking Log implementations:
+// a diagnostic callback must never leak the global trace lock or kill a
+// helper goroutine.
+func logfSafe(l Log, level LogPriority, format string, v ...interface{}) {
+	defer func() { _ = recover() }()
+	l.Logf(level, format, v...)
 }
 
 // A generic out-of-process tracer interface.
@@ -298,8 +311,10 @@ func Register(t TracerSig) {
 	t.Logf(LogDebug, "Registered tracer %s (signal set: %v)\n", t, ss)
 
 	go func(t TracerSig) {
+		// Raw Logf is unsafe here: a panicking logger would kill this
+		// goroutine (and with it, signal handling) — or the process.
 		for s := range c {
-			t.Logf(LogDebug, "Received %v; executing tracer\n", s)
+			logfSafe(t, LogDebug, "Received %v; executing tracer\n", s)
 
 			_ = Trace(t, &signalError{s}, nil)
 
@@ -313,13 +328,13 @@ func Register(t TracerSig) {
 				continue
 			}
 
-			t.Logf(LogDebug, "Resending %v to default handler\n", s)
+			logfSafe(t, LogDebug, "Resending %v to default handler\n", s)
 
 			// Re-handle the signal with the default Go behavior.
 			signal.Reset(s)
 			p, err := os.FindProcess(os.Getpid())
 			if err != nil {
-				t.Logf(LogError, "Failed to resend signal: "+
+				logfSafe(t, LogError, "Failed to resend signal: "+
 					"cannot find process object")
 				return
 			}
@@ -327,7 +342,7 @@ func Register(t TracerSig) {
 			_ = p.Signal(s)
 		}
 
-		t.Logf(LogDebug, "Signal channel closed; exiting goroutine\n")
+		logfSafe(t, LogDebug, "Signal channel closed; exiting goroutine\n")
 	}(t)
 }
 
@@ -357,6 +372,11 @@ type tracerResult struct {
 	stdOut []byte
 	err    error
 }
+
+// testHookBeforeTracerStart, when non-nil, runs in the exec goroutine
+// immediately before Cmd.Start. Test-only: it makes the start-timeout
+// handoff path deterministic.
+var testHookBeforeTracerStart func()
 
 // Executes the specified Tracer on the current process.
 //
@@ -428,12 +448,16 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 	// Report caller's goid
 	var buf [64]byte
 	n := runtime.Stack(buf[:], false)
-	idField := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))[0]
-	if goid, err := strconv.Atoi(idField); err == nil {
-		t.Logf(LogDebug, "Retrieved goid: %v\n", goid)
-		options = t.AddCallerGo(options, goid)
+	fields := strings.Fields(strings.TrimPrefix(string(buf[:n]), "goroutine "))
+	if len(fields) > 0 {
+		if goid, err := strconv.Atoi(fields[0]); err == nil {
+			t.Logf(LogDebug, "Retrieved goid: %v\n", goid)
+			options = t.AddCallerGo(options, goid)
+		} else {
+			t.Logf(LogWarning, "Failed to retrieve goid: %v\n", err)
+		}
 	} else {
-		t.Logf(LogWarning, "Failed to retrieve goid: %v\n", err)
+		t.Logf(LogWarning, "Failed to retrieve goid: empty stack header\n")
 	}
 
 	if e != nil {
@@ -466,10 +490,15 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 
 	// We now hold the trace lock.
 	// Allow another tracer to execute (i.e. by re-populating the
-	// traceLock channel) as long as the current tracer has
-	// exited.
+	// traceLock channel) as long as the current tracer has exited. When a
+	// timeout fires before the subprocess start resolves, lock release is
+	// handed to a cleanup goroutine instead (see below), so a late child
+	// can never run concurrently with the next trace.
+	unlockHandedOff := false
 	defer func() {
-		go traceUnlockRL(t, rl)
+		if !unlockHandedOff {
+			go traceUnlockRL(t, rl)
+		}
 	}()
 
 	done := make(chan tracerResult, 1)
@@ -492,13 +521,16 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 			defer traceOptions.SpawnedGs.Done()
 		}
 
-		t.Logf(LogDebug, "Starting tracer %v\n", tracer)
+		logfSafe(t, LogDebug, "Starting tracer %v\n", tracer)
 
 		var res tracerResult
 		var stdOut bytes.Buffer
 
 		tracer.Stdout = &stdOut
 
+		if testHookBeforeTracerStart != nil {
+			testHookBeforeTracerStart()
+		}
 		if startErr := tracer.Start(); startErr != nil {
 			res.err = startErr
 			done <- res
@@ -510,7 +542,7 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 		res.stdOut = stdOut.Bytes()
 		done <- res
 
-		t.Logf(LogDebug, "Tracer finished execution\n")
+		logfSafe(t, LogDebug, "Tracer finished execution\n")
 	}()
 
 	t.Logf(LogDebug, "Waiting for tracer completion...\n")
@@ -555,6 +587,50 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 
 				return
 			}
+		default:
+			// Cmd.Start itself has not resolved by the deadline.
+			// Return to the caller now; a cleanup goroutine deals
+			// with the late child and only then releases the trace
+			// lock, so no other trace can run alongside it.
+			unlockHandedOff = true
+			go func() {
+				select {
+				case <-time.After(30 * time.Second):
+					// Cmd.Start itself is wedged (e.g. a
+					// pathologically slow exec). Give up and
+					// release the lock rather than disabling
+					// tracing forever.
+					logfSafe(t, LogError,
+						"Tracer Start did not resolve; releasing trace lock\n")
+				case <-started:
+					if killErr := tracer.Process.Kill(); killErr != nil &&
+						!errors.Is(killErr, os.ErrProcessDone) {
+						logfSafe(t, LogError,
+							"Failed to kill late tracer: %v\n", killErr)
+						if kfPanic {
+							// Honors PanicOnKillFailure; in a
+							// goroutine this aborts the process,
+							// consistent with the option's intent.
+							panic(killErr)
+						}
+					}
+					// Bound the reap wait: an unkillable child must
+					// not hold the trace lock forever.
+					select {
+					case <-done:
+					case <-time.After(30 * time.Second):
+						logfSafe(t, LogError,
+							"Late tracer not reaped after kill; releasing trace lock\n")
+					}
+				case <-done:
+				}
+				traceUnlockRL(t, rl)
+			}()
+
+			err = errors.New("Tracer start timed out")
+			logfSafe(t, LogError, "%v\n", err)
+
+			return
 		}
 	case res = <-done:
 		break
@@ -576,16 +652,16 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 	}
 
 	putFn := func() error {
-		t.Logf(LogDebug, "Uploading snapshot...")
+		logfSafe(t, LogDebug, "Uploading snapshot...")
 
 		if err := t.Put(res.stdOut); err != nil {
-			t.Logf(LogError, "Failed to upload snapshot: %s",
+			logfSafe(t, LogError, "Failed to upload snapshot: %s",
 				err)
 
 			return err
 		}
 
-		t.Logf(LogDebug, "Successfully uploaded snapshot\n")
+		logfSafe(t, LogDebug, "Successfully uploaded snapshot\n")
 
 		return nil
 	}
@@ -603,6 +679,9 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 			if traceOptions.SpawnedGs != nil {
 				defer traceOptions.SpawnedGs.Done()
 			}
+			// A panicking Put/Log implementation must not kill the
+			// process from this goroutine.
+			defer func() { _ = recover() }()
 
 			_ = putFn()
 		}()
@@ -614,10 +693,15 @@ func Trace(t Tracer, e error, traceOptions *TraceOptions) (err error) {
 }
 
 func traceUnlockRL(t Tracer, rl time.Duration) {
-	t.Logf(LogDebug, "Waiting for ratelimit (%v)\n", rl)
+	// The lock MUST be released even if a diagnostic callback panics;
+	// a consumed traceLock would disable tracing for the process
+	// lifetime.
+	defer func() {
+		traceLock <- struct{}{}
+	}()
+	logfSafe(t, LogDebug, "Waiting for ratelimit (%v)\n", rl)
 	<-time.After(rl)
-	t.Logf(LogDebug, "Unlocking traceLock\n")
-	traceLock <- struct{}{}
+	logfSafe(t, LogDebug, "Unlocking traceLock\n")
 }
 
 // Create a unique error type to use during panic recovery.

--- a/bcd_sys_unsupported.go
+++ b/bcd_sys_unsupported.go
@@ -3,17 +3,18 @@
 package bt
 
 import (
-	"errors"
+	"fmt"
 )
 
 func gettid() (int, error) {
-	return 0, errors.New("Gettid() is unsupported on this system")
+	return 0, fmt.Errorf("%w: gettid", ErrUnsupportedPlatform)
 }
 
 // Call this function to allow other (non-parent) processes to trace this one.
 //
-// This is a Linux-specific utility function and is stubbed out on other
-// operating systems.
+// This is a Linux-specific utility function; on other operating systems it
+// returns an error wrapping ErrUnsupportedPlatform so callers can detect
+// that tracing permissions were NOT changed.
 func EnableTracing() error {
-	return nil
+	return fmt.Errorf("%w: process tracing", ErrUnsupportedPlatform)
 }

--- a/bcd_trace_test.go
+++ b/bcd_trace_test.go
@@ -107,9 +107,53 @@ func TestTraceNilFinalizeFailsGracefully(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unavailable") {
 		t.Fatalf("err = %v, want 'tracer unavailable' error", err)
 	}
-	// The trace lock must have been released: a second call still works.
-	if err := Trace(tr, nil, &TraceOptions{Timeout: 5 * time.Second}); err == nil {
-		t.Fatal("second Trace unexpectedly succeeded with nil Finalize")
+	// The trace lock must have been released: a second call must fail the
+	// SAME way (a lock-acquisition timeout would prove a leaked lock).
+	if err := Trace(tr, nil, &TraceOptions{Timeout: 5 * time.Second}); err == nil ||
+		!strings.Contains(err.Error(), "unavailable") {
+		t.Fatalf("second Trace = %v, want 'tracer unavailable' (trace lock leaked?)", err)
+	}
+}
+
+// TestTraceStartTimeoutHandoff pins the handoff path deterministically: the
+// timeout fires while Cmd.Start is still blocked, Trace returns a start-
+// timeout error, and the cleanup goroutine eventually releases the trace
+// lock so later traces still run.
+func TestTraceStartTimeoutHandoff(t *testing.T) {
+	defer traceTestConfig()()
+
+	release := make(chan struct{})
+	testHookBeforeTracerStart = func() { <-release }
+	defer func() { testHookBeforeTracerStart = nil }()
+
+	tr := &fakeTracer{
+		makeCmd: func() *exec.Cmd { return exec.Command("true") },
+		dto:     TraceOptions{Timeout: 5 * time.Second},
+	}
+
+	err := Trace(tr, nil, &TraceOptions{Timeout: 50 * time.Millisecond})
+	if err == nil || !strings.Contains(err.Error(), "start timed out") {
+		t.Fatalf("err = %v, want start-timeout error", err)
+	}
+
+	// Unblock the late Start; the cleanup goroutine must release the lock.
+	// The hook stays set (clearing it here would race with the blocked
+	// goroutine's earlier read); the closed channel makes it a no-op for
+	// subsequent traces, and the deferred clear is ordered by the lock
+	// handover.
+	close(release)
+
+	lockFree := make(chan error, 1)
+	go func() {
+		lockFree <- Trace(tr, nil, &TraceOptions{Timeout: 5 * time.Second})
+	}()
+	select {
+	case err := <-lockFree:
+		if err != nil {
+			t.Fatalf("post-handoff Trace = %v, want nil (lock released, tracer runs)", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("trace lock leaked by the start-timeout handoff")
 	}
 }
 

--- a/breadcrumbs.go
+++ b/breadcrumbs.go
@@ -53,10 +53,17 @@ func newBreadcrumbRing(capacity int) *breadcrumbRing {
 	return &breadcrumbRing{buf: make([]Breadcrumb, capacity)}
 }
 
+// cloneBreadcrumb detaches the attribute map from caller ownership.
+func cloneBreadcrumb(b Breadcrumb) Breadcrumb {
+	b.Attributes = cloneAnyMap(b.Attributes)
+	return b
+}
+
 func (r *breadcrumbRing) add(b Breadcrumb) {
 	if r == nil {
 		return
 	}
+	b = cloneBreadcrumb(b)
 	if b.Timestamp == 0 {
 		b.Timestamp = time.Now().UnixMilli()
 	}
@@ -93,7 +100,7 @@ func (r *breadcrumbRing) snapshot() []Breadcrumb {
 	}
 	out := make([]Breadcrumb, r.size)
 	for i := 0; i < r.size; i++ {
-		out[i] = r.buf[(r.head+i)%len(r.buf)]
+		out[i] = cloneBreadcrumb(r.buf[(r.head+i)%len(r.buf)])
 	}
 	return out
 }

--- a/bthttp/bthttp.go
+++ b/bthttp/bthttp.go
@@ -1,40 +1,71 @@
 // Package bthttp provides net/http middleware that reports panics in HTTP
-// handlers to Backtrace, enriched with request attributes.
+// handlers to Backtrace.
 //
-//	handler := bthttp.New(bthttp.Options{Repanic: true}).Handle(mux)
-//	http.ListenAndServe(":8080", handler)
+//	handler := bthttp.New(bthttp.Options{})
+//	http.ListenAndServe(":8080", handler.Handle(mux))
 //
 // Reports are sent through the client configured via bt.Options, or through
-// Options.Client when set.
+// Options.Client when set. By default only non-identifying request metadata
+// (method, protocol, registered route pattern) is attached; raw URL, host,
+// remote address, and user agent are gated behind Options.SendDefaultPII.
+//
+// The middleware wraps the http.ResponseWriter (to detect uncommitted
+// responses). The wrapper implements Flush, Hijack, Push, ReadFrom, and
+// Unwrap; handlers that type-assert the writer to a concrete type should
+// use http.NewResponseController or Unwrap instead.
 package bthttp
 
 import (
+	"bufio"
+	"io"
+	"net"
 	"net/http"
 	"time"
 
 	bt "github.com/backtrace-labs/backtrace-go"
 )
 
+// Attribute length bounds; attacker-controlled request fields are truncated.
+const (
+	maxRouteLength     = 2048
+	maxURLLength       = 4096
+	maxHostLength      = 1024
+	maxRemoteLength    = 1024
+	maxUserAgentLength = 2048
+)
+
 // Options configures the middleware.
 type Options struct {
 	// Repanic re-raises the panic after reporting so outer middleware or
 	// the net/http server recovery can run. When false the panic is
-	// swallowed and the connection is left to net/http's default
-	// handling of an aborted handler.
+	// swallowed and, if the handler had not committed a response, the
+	// middleware writes 500 Internal Server Error.
 	Repanic bool
 
 	// WaitForDelivery blocks the failing request until the report is
-	// delivered (bounded by FlushTimeout) instead of returning
+	// delivered, bounded by FlushTimeout, instead of returning
 	// immediately. Recommended when Repanic is true and the process may
 	// terminate.
 	WaitForDelivery bool
 
-	// FlushTimeout bounds WaitForDelivery. Default: 2s.
+	// FlushTimeout bounds WaitForDelivery (one deadline covering both
+	// capture and delivery). Default: 2s.
 	FlushTimeout time.Duration
 
 	// Client sends reports through a specific bt.Client instead of the
 	// global reporter.
 	Client *bt.Client
+
+	// SendDefaultPII includes the raw request path, host, remote address,
+	// and user agent with panic reports. Default false: these fields can
+	// carry personal data, tenant identifiers, or session-bearing path
+	// components.
+	SendDefaultPII bool
+
+	// RequestAttributes, when set, contributes application-approved
+	// request metadata to panic reports. The returned map is copied by
+	// the SDK; a panic inside the callback is contained and ignored.
+	RequestAttributes func(*http.Request) map[string]interface{}
 }
 
 // Handler wraps HTTP handlers with panic reporting.
@@ -53,47 +84,154 @@ func New(opts Options) *Handler {
 // Handle wraps next with panic reporting.
 func (h *Handler) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer h.recoverAndReport(r)
-		next.ServeHTTP(w, r)
+		tw := &trackingWriter{ResponseWriter: w}
+		defer h.recoverAndReport(tw, r)
+		next.ServeHTTP(tw, r)
 	})
 }
 
 // HandleFunc wraps next with panic reporting.
 func (h *Handler) HandleFunc(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer h.recoverAndReport(r)
-		next(w, r)
+		tw := &trackingWriter{ResponseWriter: w}
+		defer h.recoverAndReport(tw, r)
+		next(tw, r)
 	}
 }
 
-func (h *Handler) recoverAndReport(r *http.Request) {
+func (h *Handler) recoverAndReport(w *trackingWriter, r *http.Request) {
 	v := recover()
 	if v == nil {
 		return
 	}
 
 	attrs := map[string]interface{}{
-		"request.url":         r.URL.Path,
-		"request.method":      r.Method,
-		"request.host":        r.Host,
-		"request.remote_addr": r.RemoteAddr,
-		"request.user_agent":  r.UserAgent(),
-		"request.proto":       r.Proto,
+		"request.method": r.Method,
+		"request.proto":  r.Proto,
+	}
+	if r.Pattern != "" {
+		attrs["request.route"] = boundedString(r.Pattern, maxRouteLength)
+	}
+	if h.opts.SendDefaultPII {
+		attrs["request.url"] = boundedString(r.URL.Path, maxURLLength)
+		attrs["request.host"] = boundedString(r.Host, maxHostLength)
+		attrs["request.remote_addr"] = boundedString(r.RemoteAddr, maxRemoteLength)
+		attrs["request.user_agent"] = boundedString(r.UserAgent(), maxUserAgentLength)
+	}
+	for k, value := range h.safeRequestAttributes(r) {
+		attrs[k] = value
 	}
 
 	if h.opts.Client != nil {
-		h.opts.Client.ReportPanicValue(v, attrs)
 		if h.opts.WaitForDelivery {
-			h.opts.Client.Flush(h.opts.FlushTimeout)
+			h.opts.Client.ReportPanicValueAndFlush(v, attrs, h.opts.FlushTimeout)
+		} else {
+			h.opts.Client.ReportPanicValue(v, attrs)
 		}
+	} else if h.opts.WaitForDelivery {
+		bt.ReportPanicValueAndFlush(v, attrs, h.opts.FlushTimeout)
 	} else {
 		bt.ReportPanicValue(v, attrs)
-		if h.opts.WaitForDelivery {
-			bt.Flush(h.opts.FlushTimeout)
-		}
 	}
 
 	if h.opts.Repanic {
 		panic(v)
 	}
+	// Swallowing the panic means net/http's default handling never runs;
+	// an uncommitted response would otherwise become an empty 200 OK.
+	if !w.wroteHeader {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+}
+
+// safeRequestAttributes runs the user callback behind panic containment.
+func (h *Handler) safeRequestAttributes(r *http.Request) (out map[string]interface{}) {
+	if h.opts.RequestAttributes == nil {
+		return nil
+	}
+	defer func() { _ = recover() }()
+	produced := h.opts.RequestAttributes(r)
+	if produced == nil {
+		return nil
+	}
+	out = make(map[string]interface{}, len(produced))
+	for k, v := range produced {
+		out[k] = v
+	}
+	return out
+}
+
+func boundedString(s string, max int) string {
+	if len(s) > max {
+		return s[:max]
+	}
+	return s
+}
+
+// trackingWriter records whether a response was committed so a swallowed
+// panic can be converted into a 500 when nothing was written. It preserves
+// the optional ResponseWriter interfaces via http.NewResponseController
+// (Flush/Hijack) and direct assertions (Push/ReadFrom), and exposes Unwrap
+// for the controller.
+type trackingWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+	status      int
+}
+
+func (w *trackingWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *trackingWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	w.status = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *trackingWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *trackingWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	_ = http.NewResponseController(w.ResponseWriter).Flush()
+}
+
+func (w *trackingWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return http.NewResponseController(w.ResponseWriter).Hijack()
+}
+
+func (w *trackingWriter) Push(target string, opts *http.PushOptions) error {
+	if p, ok := w.ResponseWriter.(http.Pusher); ok {
+		return p.Push(target, opts)
+	}
+	return http.ErrNotSupported
+}
+
+func (w *trackingWriter) ReadFrom(r io.Reader) (int64, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if rf, ok := w.ResponseWriter.(io.ReaderFrom); ok {
+		return rf.ReadFrom(r)
+	}
+	return io.Copy(w.ResponseWriter, r)
+}
+
+// CloseNotify delegates to the underlying writer for handlers still using
+// the deprecated http.CloseNotifier interface.
+//
+//nolint:staticcheck // deliberate passthrough of the deprecated interface
+func (w *trackingWriter) CloseNotify() <-chan bool {
+	if cn, ok := w.ResponseWriter.(http.CloseNotifier); ok {
+		return cn.CloseNotify()
+	}
+	return nil
 }

--- a/bthttp/bthttp_test.go
+++ b/bthttp/bthttp_test.go
@@ -32,6 +32,15 @@ func (c *capture) last() map[string]interface{} {
 	return c.payloads[len(c.payloads)-1]
 }
 
+func lastAttrs(c *capture) map[string]interface{} {
+	p := c.last()
+	if p == nil {
+		return nil
+	}
+	attrs, _ := p["attributes"].(map[string]interface{})
+	return attrs
+}
+
 func newCaptureClient(t *testing.T) (*bt.Client, *capture) {
 	t.Helper()
 	cap := &capture{}
@@ -55,33 +64,116 @@ func newCaptureClient(t *testing.T) (*bt.Client, *capture) {
 	return client, cap
 }
 
-func TestMiddlewareReportsPanicsWithRequestAttributes(t *testing.T) {
+func TestMiddlewareReportsPanics(t *testing.T) {
 	client, cap := newCaptureClient(t)
 
 	h := New(Options{Client: client, WaitForDelivery: true, FlushTimeout: 5 * time.Second})
-	wrapped := h.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /checkout", func(w http.ResponseWriter, r *http.Request) {
 		panic("handler exploded")
-	}))
+	})
+	wrapped := h.Handle(mux)
 
 	req := httptest.NewRequest(http.MethodPost, "/checkout?item=1", nil)
 	req.Header.Set("User-Agent", "bthttp-test-agent")
-	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
 
 	if cap.count() != 1 {
 		t.Fatalf("reports = %d, want 1", cap.count())
 	}
-	attrs, _ := cap.last()["attributes"].(map[string]interface{})
+	attrs := lastAttrs(cap)
 	if attrs["error.message"] != "handler exploded" {
 		t.Errorf("error.message = %v", attrs["error.message"])
 	}
-	if attrs["request.url"] != "/checkout" || attrs["request.method"] != "POST" {
-		t.Errorf("request attributes wrong: url=%v method=%v", attrs["request.url"], attrs["request.method"])
+	if attrs["report_type"] != "panic" {
+		t.Errorf("report_type = %v", attrs["report_type"])
+	}
+	if attrs["request.method"] != "POST" {
+		t.Errorf("request.method = %v", attrs["request.method"])
+	}
+	if attrs["request.route"] != "POST /checkout" {
+		t.Errorf("request.route = %v", attrs["request.route"])
+	}
+
+	// PII defaults OFF: raw URL, host, remote address, user agent absent.
+	for _, key := range []string{"request.url", "request.host", "request.remote_addr", "request.user_agent"} {
+		if _, present := attrs[key]; present {
+			t.Errorf("%s sent without SendDefaultPII", key)
+		}
+	}
+
+	// A swallowed panic on an uncommitted response becomes a 500, not an
+	// empty 200.
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestMiddlewareSendDefaultPII(t *testing.T) {
+	client, cap := newCaptureClient(t)
+
+	h := New(Options{Client: client, WaitForDelivery: true, FlushTimeout: 5 * time.Second,
+		SendDefaultPII: true})
+	wrapped := h.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("with pii")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/orders?id=1", nil)
+	req.Header.Set("User-Agent", "bthttp-test-agent")
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	attrs := lastAttrs(cap)
+	if attrs["request.url"] != "/orders" {
+		t.Errorf("request.url = %v", attrs["request.url"])
 	}
 	if attrs["request.user_agent"] != "bthttp-test-agent" {
 		t.Errorf("request.user_agent = %v", attrs["request.user_agent"])
 	}
-	if attrs["report_type"] != "panic" {
-		t.Errorf("report_type = %v", attrs["report_type"])
+	if attrs["request.host"] == nil || attrs["request.remote_addr"] == nil {
+		t.Errorf("host/remote_addr missing with SendDefaultPII: %v", attrs)
+	}
+}
+
+func TestMiddlewareRequestAttributesCallback(t *testing.T) {
+	client, cap := newCaptureClient(t)
+
+	h := New(Options{Client: client, WaitForDelivery: true, FlushTimeout: 5 * time.Second,
+		RequestAttributes: func(r *http.Request) map[string]interface{} {
+			return map[string]interface{}{"tenant.id": r.Header.Get("X-Tenant")}
+		}})
+	wrapped := h.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("with callback")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-Tenant", "acme")
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	if attrs := lastAttrs(cap); attrs["tenant.id"] != "acme" {
+		t.Errorf("callback attribute missing: %v", attrs["tenant.id"])
+	}
+}
+
+func TestMiddlewarePanickingCallbackIsContained(t *testing.T) {
+	client, cap := newCaptureClient(t)
+
+	h := New(Options{Client: client, WaitForDelivery: true, FlushTimeout: 5 * time.Second,
+		RequestAttributes: func(r *http.Request) map[string]interface{} {
+			panic("callback bug")
+		}})
+	wrapped := h.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("handler panic")
+	}))
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil)) // must not panic
+
+	if cap.count() != 1 {
+		t.Fatalf("report lost to callback panic: %d", cap.count())
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
 	}
 }
 
@@ -104,6 +196,23 @@ func TestMiddlewareNoPanicPassthrough(t *testing.T) {
 	client.Flush(2 * time.Second)
 	if cap.count() != 0 {
 		t.Errorf("healthy request produced %d reports", cap.count())
+	}
+}
+
+func TestMiddlewareCommittedResponseKeptOnPanic(t *testing.T) {
+	client, _ := newCaptureClient(t)
+
+	h := New(Options{Client: client, WaitForDelivery: true, FlushTimeout: 5 * time.Second})
+	wrapped := h.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted) // response committed...
+		panic("late panic")                // ...then the handler dies
+	}))
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("status = %d; committed response must not be overwritten", rec.Code)
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -1,8 +1,8 @@
 package bt
 
 import (
+	"context"
 	"encoding/json"
-	"fmt"
 	"math/rand/v2"
 	"runtime"
 	"sync"
@@ -12,56 +12,94 @@ import (
 
 // Client is an instance-based Backtrace reporter. Multiple independent
 // clients may coexist in one process. All methods are safe for concurrent
-// use, never block the caller on network I/O, and never panic — including
-// on a nil *Client (e.g. when a NewClient error was ignored), where every
-// method is a no-op.
+// use and never panic — including on a nil *Client (e.g. when a NewClient
+// error was ignored), where every method is a no-op.
 //
-// Reports are queued to a background worker; when the queue is full new
-// reports are dropped and counted (see DroppedReports) instead of blocking.
-// Call Flush to wait for delivery of queued reports and Close to shut the
-// client down.
+// Regular Report* calls never block on network I/O or queue admission:
+// reports are queued to a background worker, and a full queue drops the
+// newest report and counts it (see Stats). Bounded synchronous waiting
+// exists only where explicitly documented: Flush/FlushContext,
+// Close/CloseContext, and ReportPanicValueAndFlush.
 type Client struct {
 	// cfgFn returns the normalized configuration. For clients created by
 	// NewClient it returns a fixed config; the legacy global client
 	// re-reads bt.Options so that historical mutate-the-global usage
-	// keeps working.
+	// keeps working. Each report snapshots the config at capture time so
+	// later global changes cannot reroute queued reports.
 	cfgFn func() Config
+
+	// internalDiag is fixed at construction and used on recovery paths,
+	// where re-reading configuration could itself fail.
+	internalDiag diag
 
 	transport *httpTransport
 
-	queue      chan clientJob
-	qmu        sync.RWMutex // guards closed + sends into queue
-	closed     bool
+	// ctx is the SDK root context; cancel aborts in-flight requests on
+	// CloseContext deadline expiry.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	queue     chan clientJob
+	enqueueMu sync.Mutex // guards closed, accepted, and queue admission
+	closed    bool
+	accepted  uint64
+	processed atomic.Uint64
+
+	// progress is a broadcast channel: replaced (and the old one closed)
+	// each time the worker finishes a job or the client closes, waking
+	// every waiter.
+	pmu      sync.Mutex
+	progress chan struct{}
+
+	closeOnce  sync.Once
 	workerDone chan struct{}
+
+	shutdownTimeout time.Duration
 
 	amu        sync.Mutex // guards attributes
 	attributes map[string]interface{}
 
 	crumbs *breadcrumbRing
 
-	dropped atomic.Uint64
+	stats internalStats
+
+	// logBusy backs the diag re-entrancy guard for this client.
+	logBusy atomic.Int32
 }
 
-// clientJob is either a queued report (data != nil) or a flush marker.
+// clientJob is a queued report with its admission sequence number.
 type clientJob struct {
-	data  *queuedReport
-	flush chan struct{}
+	seq  uint64
+	data *queuedReport
 }
 
-// queuedReport carries everything captured on the caller's goroutine;
+// queuedReport carries everything captured on the caller's goroutine,
+// including the delivery/scrubbing configuration in effect at capture time;
 // parsing and I/O happen on the worker.
 type queuedReport struct {
+	cfg         Config
 	stack       []byte
 	attributes  map[string]interface{}
 	annotations map[string]interface{}
 	classifiers []string
+	reportType  string // SDK-known type for diagnostics (never user data)
 	timestamp   int64
 }
 
+// nonBlocking is a pre-canceled context: queue admission under it makes one
+// attempt and drops immediately, never waiting.
+var nonBlocking = func() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}()
+
 // NewClient creates and starts a reporter with the given configuration.
-// It returns an error when the endpoint is missing or unparsable.
+// It returns an error when the endpoint is missing or unparsable, or when
+// an explicitly set option is invalid. The Config's top-level maps and
+// slices are cloned; the caller may reuse them afterwards.
 func NewClient(cfg Config) (*Client, error) {
-	n := cfg.normalize()
+	n := cloneConfig(cfg).normalize()
 	if err := n.validate(); err != nil {
 		return nil, err
 	}
@@ -71,27 +109,30 @@ func NewClient(cfg Config) (*Client, error) {
 // startClient wires up a client around a config source and starts its worker.
 func startClient(cfgFn func() Config) *Client {
 	cfg := cfgFn()
+	ctx, cancel := context.WithCancel(context.Background())
 	c := &Client{
-		cfgFn:      cfgFn,
-		transport:  newHTTPTransport(cfg.HTTPClient, cfg.Timeout),
-		queue:      make(chan clientJob, cfg.QueueSize),
-		workerDone: make(chan struct{}),
-		attributes: map[string]interface{}{},
-		crumbs:     newBreadcrumbRing(cfg.MaxBreadcrumbs),
+		cfgFn:           cfgFn,
+		transport:       newHTTPTransport(cfg.HTTPClient, cfg.Timeout),
+		ctx:             ctx,
+		cancel:          cancel,
+		queue:           make(chan clientJob, cfg.QueueSize),
+		progress:        make(chan struct{}),
+		workerDone:      make(chan struct{}),
+		shutdownTimeout: cfg.ShutdownTimeout,
+		attributes:      map[string]interface{}{},
+		crumbs:          newBreadcrumbRing(cfg.MaxBreadcrumbs),
 	}
+	// The re-entrancy guard needs the client's address, so wire the
+	// diagnostics after construction.
+	c.internalDiag = diag{logger: cfg.Logger, debug: cfg.Debug, busy: &c.logBusy}
 	go c.worker()
 	return c
 }
 
-func (c *Client) diag() diag {
-	cfg := c.cfgFn()
-	return diag{logger: cfg.Logger, debug: cfg.Debug}
-}
-
-// Report sends an error report. object may be an error (its message,
-// type and unwrap chain are captured) or any value convertible to a string
+// Report sends an error report. object may be an error (its message, type
+// and unwrap graph are captured) or any value convertible to a string
 // (reported as a message). A nil object is ignored. extraAttributes are
-// added to this report only; the map is not retained or mutated.
+// added to this report only; the map is copied, never retained or mutated.
 func (c *Client) Report(object interface{}, extraAttributes map[string]interface{}) {
 	if c == nil {
 		return
@@ -102,17 +143,17 @@ func (c *Client) Report(object interface{}, extraAttributes map[string]interface
 	case error:
 		c.ReportError(v, extraAttributes)
 	default:
-		c.ReportMessage(fmt.Sprint(v), extraAttributes)
+		c.ReportMessage(safeSprint(v), extraAttributes)
 	}
 }
 
-// ReportError sends a report for err, capturing its type and unwrap chain.
+// ReportError sends a report for err, capturing its type and unwrap graph.
 func (c *Client) ReportError(err error, extraAttributes map[string]interface{}) {
 	if c == nil || err == nil {
 		return
 	}
-	c.capture(captureInput{
-		message:    err.Error(),
+	c.capture(nonBlocking, captureInput{
+		message:    safeErrorString(err),
 		err:        err,
 		classifier: "error",
 		reportType: "error",
@@ -125,7 +166,7 @@ func (c *Client) ReportMessage(msg string, extraAttributes map[string]interface{
 	if c == nil {
 		return
 	}
-	c.capture(captureInput{
+	c.capture(nonBlocking, captureInput{
 		message:    msg,
 		classifier: "message",
 		reportType: "message",
@@ -133,29 +174,43 @@ func (c *Client) ReportMessage(msg string, extraAttributes map[string]interface{
 	})
 }
 
-// ReportPanicValue sends a report for a recovered panic value. It does not
-// call recover itself and does not re-panic; it is intended for middleware
-// and custom panic handlers. Call Flush afterwards when the process (or
-// goroutine) is about to die.
-//
-// Unlike regular reports, a panic report retries a full queue for up to
-// DefaultFlushTimeout before being dropped: it is likely the process's
-// last report.
+// ReportPanicValue sends a report for a recovered panic value without
+// blocking: a full queue drops the report (counted in Stats). Use
+// ReportPanicValueAndFlush when the goroutine or process is about to die
+// and delivery must be awaited.
 func (c *Client) ReportPanicValue(value interface{}, extraAttributes map[string]interface{}) {
 	if c == nil || value == nil {
 		return
 	}
+	c.capture(nonBlocking, panicCaptureInput(value, extraAttributes))
+}
+
+// ReportPanicValueAndFlush captures a recovered panic value and waits for
+// its delivery under ONE deadline covering queue admission and flushing.
+// It reports whether the report was accepted and processed in time.
+func (c *Client) ReportPanicValueAndFlush(value interface{}, extraAttributes map[string]interface{}, timeout time.Duration) bool {
+	if c == nil || value == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	seq, accepted := c.capture(ctx, panicCaptureInput(value, extraAttributes))
+	return accepted && c.flushTargetContext(ctx, seq)
+}
+
+func panicCaptureInput(value interface{}, extra map[string]interface{}) captureInput {
 	in := captureInput{
-		message:     fmt.Sprint(value),
-		classifier:  "panic",
-		reportType:  "panic",
-		extra:       extraAttributes,
-		enqueueWait: DefaultFlushTimeout,
+		message:    safeSprint(value),
+		classifier: "panic",
+		reportType: "panic",
+		extra:      extra,
 	}
 	if err, ok := value.(error); ok {
 		in.err = err
+		in.message = safeErrorString(err)
 	}
-	c.capture(in)
+	return in
 }
 
 // SetAttribute sets a client-wide attribute included in every subsequent
@@ -169,7 +224,8 @@ func (c *Client) SetAttribute(key string, value interface{}) {
 	c.attributes[key] = value
 }
 
-// SetAttributes sets multiple client-wide attributes atomically.
+// SetAttributes sets multiple client-wide attributes atomically. The map is
+// copied.
 func (c *Client) SetAttributes(attrs map[string]interface{}) {
 	if c == nil {
 		return
@@ -181,8 +237,8 @@ func (c *Client) SetAttributes(attrs map[string]interface{}) {
 	}
 }
 
-// AddBreadcrumb records a breadcrumb attached to every subsequent report as
-// part of the "breadcrumbs" annotation. Safe for concurrent use.
+// AddBreadcrumb records a breadcrumb attached to every subsequent report.
+// The breadcrumb's attribute map is copied. Safe for concurrent use.
 func (c *Client) AddBreadcrumb(b Breadcrumb) {
 	if c == nil {
 		return
@@ -190,86 +246,139 @@ func (c *Client) AddBreadcrumb(b Breadcrumb) {
 	c.crumbs.add(b)
 }
 
-// DroppedReports returns the number of reports dropped because the queue was
-// full, the client was closed, or delivery failed.
+// Stats returns an immutable snapshot of the client's report accounting.
+func (c *Client) Stats() ClientStats {
+	if c == nil {
+		return ClientStats{}
+	}
+	return c.stats.snapshot()
+}
+
+// DroppedReports returns the total number of reports discarded for any
+// reason (queue full, closed, sampling, BeforeSend, serialization, size
+// budgets, rate limiting, network or server failure, internal error).
+// See Stats for the per-reason breakdown.
 func (c *Client) DroppedReports() uint64 {
 	if c == nil {
 		return 0
 	}
-	return c.dropped.Load()
+	return c.stats.droppedTotal()
 }
 
-// flushPollInterval paces retries when the queue is too full to accept a
-// flush marker or a panic report immediately.
-const flushPollInterval = 10 * time.Millisecond
+// FlushContext blocks until every report accepted BEFORE the call has been
+// processed, or until ctx is done. Reports enqueued after the call do not
+// extend the wait (strict capture-time barrier). It returns true when the
+// pre-call backlog was processed. Flushing proves local processing and
+// send completion, not backend acceptance.
+func (c *Client) FlushContext(ctx context.Context) bool {
+	if c == nil {
+		return true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.enqueueMu.Lock()
+	target := c.accepted
+	c.enqueueMu.Unlock()
+	return c.flushTargetContext(ctx, target)
+}
 
-// Flush blocks until all reports queued at the time of the call have been
-// processed, or until timeout elapses. It reports whether the drain
-// completed in time. Unlike the legacy FinishSendingReports, Flush never
-// stops the worker: the client remains fully usable afterwards.
+// Flush is FlushContext with a timeout. The client stays fully usable
+// afterwards.
 func (c *Client) Flush(timeout time.Duration) bool {
 	if c == nil {
 		return true
 	}
-	marker := make(chan struct{})
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return c.FlushContext(ctx)
+}
 
+// flushTargetContext waits until the worker has processed the report with
+// sequence number target. The broadcast channel is grabbed before each
+// re-check so an advance signaled in between cannot be lost.
+func (c *Client) flushTargetContext(ctx context.Context, target uint64) bool {
 	for {
-		c.qmu.RLock()
-		if c.closed {
-			c.qmu.RUnlock()
-			// Close drains the queue; wait for the worker to
-			// finish, bounded by the timeout.
-			select {
-			case <-c.workerDone:
-				return true
-			case <-timer.C:
-				return false
-			}
+		wait := c.progressCh()
+		if c.processed.Load() >= target {
+			return true
 		}
-		// Non-blocking attempt only: holding qmu across a blocking
-		// send would stall every Report() caller behind a queued
-		// Close (RWMutex writer preference).
 		select {
-		case c.queue <- clientJob{flush: marker}:
-			c.qmu.RUnlock()
-			select {
-			case <-marker:
-				return true
-			case <-timer.C:
-				return false
-			}
-		default:
-		}
-		c.qmu.RUnlock()
-
-		select {
-		case <-timer.C:
+		case <-ctx.Done():
 			return false
-		case <-time.After(flushPollInterval):
+		case <-wait:
+		case <-c.workerDone:
+			return c.processed.Load() >= target
 		}
 	}
 }
 
-// Close drains the queue, stops the worker, and releases the client.
-// Subsequent reports are dropped (and counted). Close is idempotent.
-// Call Flush first if you need a bounded wait; Close waits for the full
-// drain (each send is bounded by the configured timeout).
+// progressCh returns the current broadcast generation channel.
+func (c *Client) progressCh() <-chan struct{} {
+	c.pmu.Lock()
+	ch := c.progress
+	c.pmu.Unlock()
+	return ch
+}
+
+// signalProgress wakes every waiter (flushers and blocked panic enqueuers).
+func (c *Client) signalProgress() {
+	c.pmu.Lock()
+	close(c.progress)
+	c.progress = make(chan struct{})
+	c.pmu.Unlock()
+}
+
+// CloseContext drains the queue, stops the worker, and releases the client.
+// If ctx expires first, in-flight and queued submissions are cancelled and
+// CloseContext returns false. Subsequent reports are dropped (and counted).
+// Safe to call multiple times.
 //
 // Close and Flush must not be called from inside a BeforeSend hook: the
 // hook runs on the worker goroutine those calls wait on.
+func (c *Client) CloseContext(ctx context.Context) bool {
+	if c == nil {
+		return true
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c.beginClose()
+
+	select {
+	case <-c.workerDone:
+		c.cancel()
+		c.transport.closeIdleConnections()
+		return true
+	case <-ctx.Done():
+		// Abort the current request and cause queued requests to fail
+		// quickly; the worker still exits on its own.
+		c.cancel()
+		c.transport.closeIdleConnections()
+		return false
+	}
+}
+
+// Close drains the queue and stops the worker, bounded by the configured
+// ShutdownTimeout (default 5s). Call Flush first if you need a distinct
+// delivery guarantee. Close is idempotent.
 func (c *Client) Close() {
 	if c == nil {
 		return
 	}
-	c.qmu.Lock()
-	if !c.closed {
+	ctx, cancel := context.WithTimeout(context.Background(), c.shutdownTimeout)
+	defer cancel()
+	_ = c.CloseContext(ctx)
+}
+
+func (c *Client) beginClose() {
+	c.closeOnce.Do(func() {
+		c.enqueueMu.Lock()
 		c.closed = true
 		close(c.queue)
-	}
-	c.qmu.Unlock()
-	<-c.workerDone
+		c.enqueueMu.Unlock()
+		c.signalProgress()
+	})
 }
 
 // captureInput bundles the per-call capture parameters.
@@ -279,32 +388,38 @@ type captureInput struct {
 	classifier string
 	reportType string
 	extra      map[string]interface{}
-	// enqueueWait bounds how long a full queue is retried before the
-	// report is dropped; zero means drop immediately (never block).
-	enqueueWait time.Duration
 }
 
 // capture assembles everything that must be observed on the caller's
-// goroutine (stack, attribute snapshot) and enqueues the report. It never
-// blocks on the queue and never panics.
-func (c *Client) capture(in captureInput) {
-	defer c.recoverInternal("capture")
+// goroutine (stack, attribute snapshot, delivery config) and enqueues the
+// report. With a nil ctx it never blocks; with a ctx it retries queue
+// admission until the context is done. It never panics.
+func (c *Client) capture(ctx context.Context, in captureInput) (seq uint64, accepted bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			// Type-only: the panic value may carry user data.
+			c.stats.drop(dropInternal)
+			c.internalDiag.logf("internal error while capturing report (please report to backtrace-labs/backtrace-go): %T", r)
+			seq, accepted = 0, false
+		}
+	}()
 
-	cfg := c.cfgFn()
+	cfg := cloneConfig(c.cfgFn())
 
 	if cfg.SampleRate < 1 && rand.Float64() >= cfg.SampleRate {
-		c.diag().logf("report sampled out (SampleRate=%v)", cfg.SampleRate)
-		return
+		c.stats.drop(dropSampled)
+		c.internalDiag.logf("report sampled out (SampleRate=%v)", cfg.SampleRate)
+		return 0, false
 	}
 
 	attributes := map[string]interface{}{}
 	for k, v := range staticAttributes() {
 		attributes[k] = v
 	}
-	updateAttrsWithProcMemInfo(attributes, c.diag())
+	updateAttrsWithProcMemInfo(attributes, c.internalDiag)
 	runtimeAttributes(attributes)
 
-	// Config-level attributes (treated as read-only after NewClient).
+	// Config-level attributes (cloned at capture; safe to iterate).
 	for k, v := range cfg.Attributes {
 		attributes[k] = v
 	}
@@ -322,7 +437,7 @@ func (c *Client) capture(in captureInput) {
 	annotations := map[string]interface{}{}
 
 	if in.err != nil {
-		chain := unwrapErrorChain(in.err, cfg.MaxErrorDepth)
+		chain := unwrapErrorChain(in.err, cfg.MaxErrorDepth, cfg.MaxErrorNodes)
 		if len(chain) > 0 {
 			attributes["error.type"] = chain[0].Type
 			annotations["Error Chain"] = chain
@@ -342,68 +457,86 @@ func (c *Client) capture(in captureInput) {
 		annotations["breadcrumbs"] = crumbs
 	}
 
-	c.enqueue(clientJob{data: &queuedReport{
-		stack:       captureStack(cfg.CaptureAllGoroutines),
+	return c.enqueueContext(ctx, clientJob{data: &queuedReport{
+		cfg:         cfg,
+		stack:       captureStack(cfg.CaptureAllGoroutines, cfg.MaxStackBytes),
 		attributes:  attributes,
 		annotations: annotations,
 		classifiers: classifiers,
+		reportType:  in.reportType,
 		timestamp:   time.Now().Unix(),
-	}}, in.enqueueWait)
+	}})
 }
 
-// enqueue queues a job without ever holding qmu across a blocking send.
-// With wait <= 0 a full queue drops the report immediately (regular
-// reports never block the caller). A positive wait — used for panic
-// reports, which are the process's last words — retries for up to that
-// duration before dropping.
-func (c *Client) enqueue(j clientJob, wait time.Duration) {
-	deadline := time.Now().Add(wait)
+// enqueueContext admits a job to the queue under the enqueue lock, assigning
+// its sequence number. A full queue is retried on worker progress until ctx
+// is done (the nonBlocking sentinel makes exactly one attempt). The lock is
+// never held across a blocking operation.
+func (c *Client) enqueueContext(ctx context.Context, j clientJob) (uint64, bool) {
+	if ctx == nil {
+		ctx = nonBlocking
+	}
 	for {
-		c.qmu.RLock()
+		// Grab the broadcast channel BEFORE the admission attempt: any
+		// queue space freed after the attempt comes from a completion
+		// that closes exactly this channel, so the wake-up cannot be
+		// lost in between.
+		wait := c.progressCh()
+
+		c.enqueueMu.Lock()
 		if c.closed {
-			c.qmu.RUnlock()
-			c.dropped.Add(1)
-			c.diag().logf("report dropped: client closed")
-			return
+			c.enqueueMu.Unlock()
+			c.stats.drop(dropClosed)
+			c.internalDiag.logf("report dropped: client closed")
+			return 0, false
 		}
+		next := c.accepted + 1
+		j.seq = next
 		select {
 		case c.queue <- j:
-			c.qmu.RUnlock()
-			return
+			c.accepted = next
+			c.enqueueMu.Unlock()
+			c.stats.accepted.Add(1)
+			return next, true
 		default:
 		}
-		c.qmu.RUnlock()
+		c.enqueueMu.Unlock()
 
-		if wait <= 0 || !time.Now().Before(deadline) {
-			c.dropped.Add(1)
-			c.diag().logf("report dropped: queue full (capacity %d)", cap(c.queue))
-			return
+		select {
+		case <-ctx.Done():
+			c.stats.drop(dropQueueFull)
+			c.internalDiag.logf("report dropped: queue full (capacity %d)", cap(c.queue))
+			return 0, false
+		case <-wait:
+		case <-c.workerDone:
+			c.stats.drop(dropClosed)
+			return 0, false
 		}
-		time.Sleep(flushPollInterval)
 	}
 }
 
 // worker is the single consumer of the queue. It exits when Close closes the
-// queue, after draining remaining jobs.
+// queue, after draining remaining jobs. Every processed job broadcasts
+// progress to flushers and blocked panic enqueuers.
 func (c *Client) worker() {
 	defer close(c.workerDone)
+	defer c.signalProgress()
 	for j := range c.queue {
-		if j.flush != nil {
-			close(j.flush)
-			continue
-		}
 		c.processAndSend(j.data)
+		c.processed.Store(j.seq)
+		c.signalProgress()
 	}
 }
 
 // processAndSend turns a queued report into the wire payload and delivers
-// it. Runs on the worker goroutine; all failure modes degrade to a debug log
-// plus the dropped counter.
+// it, using the configuration snapshot taken at capture time. Runs on the
+// worker goroutine; all failure modes degrade to a debug log plus a stats
+// counter.
 func (c *Client) processAndSend(qr *queuedReport) {
 	defer c.recoverInternal("processAndSend")
 
-	cfg := c.cfgFn()
-	d := diag{logger: cfg.Logger, debug: cfg.Debug}
+	cfg := qr.cfg
+	d := diag{logger: cfg.Logger, debug: cfg.Debug, busy: &c.logBusy}
 
 	// Machine and build metadata are gathered lazily (never at import
 	// time) and merged without overriding caller-provided values.
@@ -411,6 +544,15 @@ func (c *Client) processAndSend(qr *queuedReport) {
 		for k, v := range machineAttributes(d) {
 			if _, exists := qr.attributes[k]; !exists {
 				qr.attributes[k] = v
+			}
+		}
+		// The stable machine identifier is opt-in, and its probe only
+		// runs once someone opts in.
+		if cfg.SendMachineID {
+			if guid := machineGUID(d); guid != "" {
+				if _, exists := qr.attributes["guid"]; !exists {
+					qr.attributes["guid"] = guid
+				}
 			}
 		}
 	}
@@ -430,6 +572,9 @@ func (c *Client) processAndSend(qr *queuedReport) {
 		mode:         cfg.SourceCode,
 		contextLines: cfg.ContextLineCount,
 		tabWidth:     cfg.TabWidth,
+		roots:        cfg.SourceRoots,
+		maxFileBytes: cfg.MaxSourceFileBytes,
+		maxTotal:     cfg.MaxSourceBytes,
 	})
 
 	report := &ReportData{
@@ -441,11 +586,18 @@ func (c *Client) processAndSend(qr *queuedReport) {
 		Threads:     threads,
 		SourceCode:  sourceCode,
 		MainThread:  mainThread,
-		Attachments: append([]string(nil), cfg.AttachmentPaths...),
+	}
+	// A negative MaxAttachments disables attachments entirely (documented);
+	// don't even open the files.
+	if cfg.MaxAttachments >= 0 {
+		report.Attachments = append([]string(nil), cfg.AttachmentPaths...)
 	}
 
 	if cfg.BeforeSend != nil {
 		if modified := c.runBeforeSend(cfg.BeforeSend, report, d); modified == nil {
+			// Counts both deliberate drops (hook returned nil) and
+			// panicking hooks (fail closed).
+			c.stats.drop(dropBeforeSend)
 			d.logf("report %s dropped by BeforeSend", report.UUID)
 			return
 		} else {
@@ -455,8 +607,14 @@ func (c *Client) processAndSend(qr *queuedReport) {
 
 	body, err := json.Marshal(report.toWire())
 	if err != nil {
-		c.dropped.Add(1)
-		d.logf("report %s dropped: marshal failed: %v", report.UUID, err)
+		c.stats.drop(dropSerialization)
+		d.logf("report %s dropped: serialization failed (%T)", report.UUID, err)
+		return
+	}
+	if len(body) > cfg.MaxReportBytes {
+		c.stats.drop(dropOversize)
+		d.logf("report %s dropped: %d bytes exceeds the %d-byte report limit",
+			report.UUID, len(body), cfg.MaxReportBytes)
 		return
 	}
 
@@ -471,15 +629,22 @@ func (c *Client) processAndSend(qr *queuedReport) {
 		}
 	}
 
-	if cfg.Debug {
-		pretty, _ := json.MarshalIndent(report.toWire(), "", "  ")
-		d.logf("sending report %s to %s\n%s", report.UUID, redactURL(cfg.submissionURL()), pretty)
-	}
+	// Diagnostics are payload-free by design: report contents are never
+	// logged (debug logging is often enabled during incidents, exactly
+	// when secrets are most likely to be present).
+	d.logf("sending report %s (type=%s, json_bytes=%d, attachments=%d, destination=%s)",
+		report.UUID, qr.reportType, len(body),
+		len(report.Attachments)+len(inline), redactURL(cfg.submissionURL()))
 
-	if err := c.transport.send(cfg.submissionURL(), body, report.Attachments, inline, d); err != nil {
-		c.dropped.Add(1)
+	reason, err := c.transport.send(c.ctx, cfg.submissionURL(), body,
+		report.Attachments, inline, cfg.attachmentLimits(), d)
+	if err != nil {
+		c.stats.drop(reason)
 		d.logf("report %s dropped: %v", report.UUID, err)
+		return
 	}
+	c.stats.delivered.Add(1)
+	d.logf("report %s delivered", report.UUID)
 }
 
 // runBeforeSend isolates user hook panics from the worker. A panicking hook
@@ -488,8 +653,10 @@ func (c *Client) processAndSend(qr *queuedReport) {
 func (c *Client) runBeforeSend(hook func(*ReportData) *ReportData, report *ReportData, d diag) (out *ReportData) {
 	defer func() {
 		if r := recover(); r != nil {
-			c.dropped.Add(1)
-			d.logf("BeforeSend panicked (%v); dropping report %s", r, report.UUID)
+			// The caller's nil branch performs the stats accounting.
+			// Log only the TYPE of the panic value: the hook exists to
+			// scrub data, so its panic payload may itself be sensitive.
+			d.logf("BeforeSend panicked (%T); dropping report %s", r, report.UUID)
 			out = nil
 		}
 	}()
@@ -497,24 +664,39 @@ func (c *Client) runBeforeSend(hook func(*ReportData) *ReportData, report *Repor
 }
 
 // recoverInternal is the last line of defense: an SDK bug must never crash
-// the host application.
+// the host application. It uses the fixed construction-time diagnostics and
+// never re-enters configuration code.
 func (c *Client) recoverInternal(where string) {
 	if r := recover(); r != nil {
+		// Type-only for the panic value: json.Marshal re-panics user
+		// MarshalJSON panics, whose contents may be sensitive. The stack
+		// is SDK frames and is needed for bug reports.
+		c.stats.drop(dropInternal)
 		buf := make([]byte, 4096)
 		n := runtime.Stack(buf, false)
-		c.diag().logf("internal error in %s (please report to backtrace-labs/backtrace-go): %v\n%s", where, r, buf[:n])
+		c.internalDiag.logf("internal error in %s (please report to backtrace-labs/backtrace-go): %T\n%s", where, r, buf[:n])
 	}
 }
 
 // captureStack returns the formatted stack trace of the calling goroutine,
-// or of all goroutines when all is true.
-func captureStack(all bool) []byte {
-	buf := make([]byte, 1024)
+// or of all goroutines when all is true, capped at maxBytes.
+func captureStack(all bool, maxBytes int) []byte {
+	if maxBytes < 1024 {
+		maxBytes = 1024
+	}
+	size := 64 << 10
+	if size > maxBytes {
+		size = maxBytes
+	}
 	for {
+		buf := make([]byte, size)
 		n := runtime.Stack(buf, all)
-		if n < len(buf) {
+		if n < len(buf) || size == maxBytes {
 			return buf[:n]
 		}
-		buf = make([]byte, 2*len(buf))
+		size *= 2
+		if size > maxBytes {
+			size = maxBytes
+		}
 	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package bt
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -53,7 +55,10 @@ func TestNewClientValidation(t *testing.T) {
 }
 
 func TestClientReportDelivery(t *testing.T) {
-	c, rs := newTestClient(t, nil)
+	c, rs := newTestClient(t, func(cfg *Config) {
+		// Source text is opt-in; this test asserts context snippets.
+		cfg.SourceCode = SourceCodeContext
+	})
 
 	c.Report(errors.New("client error"), map[string]interface{}{"who": "client"})
 	if !c.Flush(5 * time.Second) {
@@ -335,9 +340,11 @@ func TestBreadcrumbsRingAndAnnotation(t *testing.T) {
 	}
 }
 
-// TestPanicReportRetriesFullQueue pins the bounded blocking enqueue for
-// panic reports: with the queue full they retry instead of dropping.
-func TestPanicReportRetriesFullQueue(t *testing.T) {
+// TestPanicAndFlushRetriesFullQueue pins ReportPanicValueAndFlush: with the
+// queue full it retries admission under its single deadline instead of
+// dropping, then waits for delivery. Plain ReportPanicValue stays
+// non-blocking.
+func TestPanicAndFlushRetriesFullQueue(t *testing.T) {
 	block := make(chan struct{})
 	c, rs := newTestClient(t, func(cfg *Config) {
 		cfg.QueueSize = 1
@@ -358,24 +365,33 @@ func TestPanicReportRetriesFullQueue(t *testing.T) {
 	}
 	c.ReportMessage("fills the queue", nil)
 
-	done := make(chan struct{})
+	// Plain ReportPanicValue must return immediately (drop + count).
+	before := c.Stats().QueueFull
+	c.ReportPanicValue("non-blocking panic", nil)
+	if got := c.Stats().QueueFull; got != before+1 {
+		t.Errorf("non-blocking panic with full queue: QueueFull = %d, want %d", got, before+1)
+	}
+
+	done := make(chan bool, 1)
 	go func() {
-		c.ReportPanicValue("panic while queue full", nil)
-		close(done)
+		done <- c.ReportPanicValueAndFlush("panic while queue full", nil, 10*time.Second)
 	}()
 
 	select {
 	case <-done:
-		t.Fatal("panic report returned immediately: dropped instead of retrying")
+		t.Fatal("ReportPanicValueAndFlush returned immediately: dropped instead of retrying")
 	case <-time.After(100 * time.Millisecond):
-		// Still retrying, as intended.
+		// Still retrying under its deadline, as intended.
 	}
 
 	unblock()
 	select {
-	case <-done:
+	case delivered := <-done:
+		if !delivered {
+			t.Error("ReportPanicValueAndFlush = false after queue freed within deadline")
+		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("panic report never enqueued after queue freed")
+		t.Fatal("ReportPanicValueAndFlush never returned after queue freed")
 	}
 	if !c.Flush(5 * time.Second) {
 		t.Fatal("Flush timed out")
@@ -578,6 +594,278 @@ func TestAttachmentsMultipartSubmission(t *testing.T) {
 	}
 }
 
+type testPanicMethodError struct{}
+
+func (*testPanicMethodError) Error() string { panic("Error panic") }
+
+type testPanicStringer struct{}
+
+func (testPanicStringer) String() string { panic("String panic") }
+
+type testPanicLogger struct{}
+
+func (testPanicLogger) Printf(string, ...interface{}) { panic("logger panic") }
+
+func mustNotPanic(t *testing.T, name string, f func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("%s let an application panic escape: %v", name, r)
+		}
+	}()
+	f()
+}
+
+// TestPublicReportingContainsApplicationPanics pins the "never panic"
+// contract at every boundary that executes caller-controlled code: error
+// and stringer implementations, unwrap methods, and the diagnostic logger.
+func TestPublicReportingContainsApplicationPanics(t *testing.T) {
+	c, _ := newTestClient(t, func(cfg *Config) {
+		cfg.Debug = true
+		cfg.Logger = testPanicLogger{}
+	})
+
+	var typedNil *testPanicMethodError
+	var err error = typedNil // non-nil interface, panicking Error()
+
+	mustNotPanic(t, "ReportError", func() { c.ReportError(err, nil) })
+	mustNotPanic(t, "Report", func() { c.Report(testPanicStringer{}, nil) })
+	mustNotPanic(t, "ReportPanicValue", func() { c.ReportPanicValue(testPanicStringer{}, nil) })
+	mustNotPanic(t, "ReportPanicValueAndFlush", func() {
+		c.ReportPanicValueAndFlush(testPanicStringer{}, nil, 100*time.Millisecond)
+	})
+	mustNotPanic(t, "Flush", func() { _ = c.Flush(time.Second) })
+}
+
+// reentrantLogger forwards every diagnostic line back into the SDK — the
+// logging-adapter pattern that historically recursed to a fatal stack
+// overflow. depth tracks the maximum observed nesting.
+type reentrantLogger struct {
+	c     *Client
+	depth atomic.Int32
+	max   atomic.Int32
+}
+
+func (l *reentrantLogger) Printf(format string, v ...interface{}) {
+	d := l.depth.Add(1)
+	defer l.depth.Add(-1)
+	if d > l.max.Load() {
+		l.max.Store(d)
+	}
+	if d > 25 {
+		// A guard failure would blow the stack long before this, but
+		// bail out rather than crash the whole test binary.
+		return
+	}
+	l.c.ReportMessage("from logger", nil)
+}
+
+// TestReentrantLoggerIsContained pins the diag re-entrancy guard: a Logger
+// that reports back into the SDK must not recurse unboundedly on the
+// closed-client or full-queue drop paths.
+func TestReentrantLoggerIsContained(t *testing.T) {
+	logger := &reentrantLogger{}
+	c, _ := newTestClient(t, func(cfg *Config) {
+		cfg.Debug = true
+		cfg.Logger = logger
+		cfg.QueueSize = 1
+	})
+	logger.c = c
+
+	// Closed-client drop path: deterministic infinite recursion before
+	// the guard existed.
+	c.Close()
+	c.ReportMessage("after close", nil)
+
+	if got := logger.max.Load(); got > 2 {
+		t.Errorf("re-entrant logger nested to depth %d; guard not effective", got)
+	}
+}
+
+// TestSourceMetadataDefault pins the production-safe default: frames carry
+// path/line metadata but no source text leaves the host.
+func TestSourceMetadataDefault(t *testing.T) {
+	c, rs := newTestClient(t, nil) // no SourceCode override
+
+	c.ReportMessage("metadata only", nil)
+	if !c.Flush(5 * time.Second) {
+		t.Fatal("Flush timed out")
+	}
+
+	sources, _ := rs.last()["sourceCode"].(map[string]interface{})
+	if len(sources) == 0 {
+		t.Fatal("metadata mode should still reference paths")
+	}
+	for id, v := range sources {
+		sc, _ := v.(map[string]interface{})
+		if sc == nil {
+			continue
+		}
+		if text, _ := sc["text"].(string); text != "" {
+			t.Errorf("source entry %s carries text in metadata mode", id)
+		}
+		if path, _ := sc["path"].(string); path == "" {
+			t.Errorf("source entry %s missing path", id)
+		}
+	}
+}
+
+// TestFlushIsCaptureTimeBarrier pins the sequence-based flush: reports
+// enqueued after Flush is called must not extend its wait.
+func TestFlushIsCaptureTimeBarrier(t *testing.T) {
+	block := make(chan struct{})
+	c, rs := newTestClient(t, func(cfg *Config) {
+		cfg.QueueSize = 64
+	})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(block) }) }
+	t.Cleanup(unblock)
+
+	rs.mu.Lock()
+	rs.block = block
+	rs.mu.Unlock()
+
+	c.ReportMessage("pre-flush", nil)
+	select {
+	case <-rs.entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker never reached the transport")
+	}
+
+	flushed := make(chan bool, 1)
+	go func() { flushed <- c.Flush(10 * time.Second) }()
+
+	// Concurrent producers keep pouring reports in AFTER the flush call.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					c.ReportMessage("post-flush noise", nil)
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond) // flush is now waiting on the barrier
+	unblock()
+
+	select {
+	case ok := <-flushed:
+		if !ok {
+			t.Error("Flush = false although its pre-call backlog drained")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Flush starved by post-call producers (not a capture-time barrier)")
+	}
+	close(stop)
+	wg.Wait()
+	c.Flush(10 * time.Second)
+}
+
+// TestStatsBreakdown pins the reasoned discard counters.
+func TestStatsBreakdown(t *testing.T) {
+	c, rs := newTestClient(t, func(cfg *Config) {
+		cfg.BeforeSend = func(r *ReportData) *ReportData {
+			if r.Attributes["drop.me"] == true {
+				return nil
+			}
+			return r
+		}
+	})
+
+	c.ReportMessage("delivered", nil)
+	c.ReportMessage("hook-dropped", map[string]interface{}{"drop.me": true})
+	if !c.Flush(5 * time.Second) {
+		t.Fatal("Flush timed out")
+	}
+
+	stats := c.Stats()
+	if stats.Accepted != 2 {
+		t.Errorf("Accepted = %d, want 2", stats.Accepted)
+	}
+	if stats.Delivered != 1 {
+		t.Errorf("Delivered = %d, want 1", stats.Delivered)
+	}
+	if stats.BeforeSend != 1 {
+		t.Errorf("BeforeSend drops = %d, want 1", stats.BeforeSend)
+	}
+	if rs.count() != 1 {
+		t.Errorf("server received %d reports, want 1", rs.count())
+	}
+
+	// Server rejection is classified separately.
+	rs.mu.Lock()
+	rs.status = http.StatusInternalServerError
+	rs.mu.Unlock()
+	c.ReportMessage("rejected", nil)
+	c.Flush(5 * time.Second)
+	if got := c.Stats().ServerReject; got != 1 {
+		t.Errorf("ServerReject = %d, want 1", got)
+	}
+	if c.DroppedReports() != c.Stats().BeforeSend+c.Stats().ServerReject {
+		t.Errorf("DroppedReports = %d, want sum of reasons", c.DroppedReports())
+	}
+}
+
+// TestCloseContextCancelsBlockedTransport pins bounded shutdown: a stuck
+// transport cannot hold CloseContext past its deadline, and the SDK root
+// context aborts the in-flight request.
+func TestCloseContextCancelsBlockedTransport(t *testing.T) {
+	block := make(chan struct{})
+	c, rs := newTestClient(t, nil)
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(block) }) }
+	t.Cleanup(unblock)
+
+	rs.mu.Lock()
+	rs.block = block
+	rs.mu.Unlock()
+
+	c.ReportMessage("stuck in flight", nil)
+	select {
+	case <-rs.entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker never reached the transport")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	completed := c.CloseContext(ctx)
+	if completed {
+		t.Error("CloseContext reported clean completion despite a blocked transport")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("CloseContext took %v; deadline not honored", elapsed)
+	}
+	unblock()
+	// The worker exits on its own after cancellation aborts the request.
+	select {
+	case <-c.workerDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker leaked after CloseContext")
+	}
+}
+
+// TestCaptureStackCap pins the stack budget.
+func TestCaptureStackCap(t *testing.T) {
+	out := captureStack(true, 2048)
+	if len(out) > 2048 {
+		t.Errorf("stack = %d bytes, cap 2048", len(out))
+	}
+	if len(out) == 0 {
+		t.Error("empty stack")
+	}
+}
+
 // TestNilClientIsSafe pins the documented contract: every method on a nil
 // *Client (ignored NewClient error) is a safe no-op.
 func TestNilClientIsSafe(t *testing.T) {
@@ -592,10 +880,80 @@ func TestNilClientIsSafe(t *testing.T) {
 	if got := c.DroppedReports(); got != 0 {
 		t.Errorf("DroppedReports on nil = %d", got)
 	}
+	if got := c.Stats(); got != (ClientStats{}) {
+		t.Errorf("Stats on nil = %+v", got)
+	}
 	if !c.Flush(time.Millisecond) {
 		t.Error("Flush on nil client should trivially succeed")
 	}
+	if !c.FlushContext(context.Background()) {
+		t.Error("FlushContext on nil client should trivially succeed")
+	}
+	if !c.ReportPanicValueAndFlush("v", nil, time.Millisecond) {
+		t.Error("ReportPanicValueAndFlush on nil client should trivially succeed")
+	}
+	if !c.CloseContext(context.Background()) {
+		t.Error("CloseContext on nil client should trivially succeed")
+	}
 	c.Close()
+}
+
+// TestNegativeMaxAttachmentsDisables pins the documented contract: a
+// negative MaxAttachments sends NO attachments (privacy opt-out), rather
+// than removing the count cap.
+func TestNegativeMaxAttachmentsDisables(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.log")
+	if err := os.WriteFile(path, []byte("must not upload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, rs := newTestClient(t, func(cfg *Config) {
+		cfg.AttachmentPaths = []string{path}
+		cfg.MaxAttachments = -1
+	})
+	c.ReportMessage("no attachments", nil)
+	if !c.Flush(5 * time.Second) {
+		t.Fatal("Flush timed out")
+	}
+
+	if rs.count() != 1 {
+		t.Fatalf("reports = %d, want 1", rs.count())
+	}
+	for name := range rs.lastAttachments() {
+		if strings.HasPrefix(name, "attachment_secret") {
+			t.Errorf("attachment sent despite MaxAttachments=-1: %s", name)
+		}
+	}
+}
+
+// TestSourceRootsSymlinkDenied pins the symlink-resolution fix: a link
+// under an allowed root pointing outside it must not smuggle content in.
+func TestSourceRootsSymlinkDenied(t *testing.T) {
+	allowedDir := t.TempDir()
+	secretDir := t.TempDir()
+	secret := filepath.Join(secretDir, "secret.go")
+	if err := os.WriteFile(secret, []byte("classified\nlines\nhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(allowedDir, "linked.go")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	stack := "goroutine 1 [running]:\n" +
+		"main.a()\n" +
+		"\t" + link + ":2 +0x1\n"
+
+	_, sources, _ := buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeContext, contextLines: 2, tabWidth: 8,
+		roots: []string{allowedDir},
+	})
+	for _, sc := range sources {
+		if sc.Text != "" {
+			t.Errorf("symlink escaped SourceRoots: %q", sc.Text)
+		}
+	}
 }
 
 func TestUUID4Format(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package bt
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -15,36 +16,49 @@ import (
 type SourceCodeMode string
 
 const (
-	// SourceCodeContext embeds only ContextLineCount lines around each
-	// stack frame. This is the default: it keeps payloads small and avoids
-	// shipping whole files off the host.
+	// SourceCodeMetadata reports file path and line metadata for each
+	// frame but embeds no source text. This is the production-safe
+	// default: no application source ever leaves the host.
+	SourceCodeMetadata SourceCodeMode = "metadata"
+
+	// SourceCodeContext embeds ContextLineCount lines around each stack
+	// frame. Opt-in; consider SourceRoots to constrain which files may
+	// be read.
 	SourceCodeContext SourceCodeMode = "context"
 
 	// SourceCodeFile embeds the entire source file referenced by each
 	// frame (the SDK's historical behavior). Opt-in.
 	SourceCodeFile SourceCodeMode = "file"
 
-	// SourceCodeNone disables source code capture entirely.
+	// SourceCodeNone disables source references entirely.
 	SourceCodeNone SourceCodeMode = "none"
 )
 
 // Defaults applied by NewClient when the corresponding Config field is zero.
 const (
-	// DefaultTimeout is the per-request HTTP timeout.
+	// DefaultTimeout is the per-request submission deadline. It is
+	// enforced with an SDK-owned context even when a custom HTTPClient
+	// is supplied.
 	DefaultTimeout = 30 * time.Second
+
+	// DefaultShutdownTimeout bounds Close.
+	DefaultShutdownTimeout = 5 * time.Second
 
 	// DefaultQueueSize is the capacity of the in-memory report queue.
 	// When the queue is full new reports are dropped (never blocking the
-	// caller) and counted; see Client.DroppedReports.
+	// caller) and counted; see Client.Stats.
 	DefaultQueueSize = 128
 
 	// DefaultContextLineCount is the number of source lines captured
 	// above and below a stack frame line in SourceCodeContext mode.
 	DefaultContextLineCount = 8
 
-	// DefaultMaxErrorDepth caps how many wrapped errors are walked when
-	// capturing an error chain.
-	DefaultMaxErrorDepth = 100
+	// DefaultMaxErrorDepth caps how deep wrapped-error graphs are walked.
+	DefaultMaxErrorDepth = 32
+
+	// DefaultMaxErrorNodes caps how many errors one report's error graph
+	// may contain (errors.Join fan-out included).
+	DefaultMaxErrorNodes = 100
 
 	// DefaultMaxBreadcrumbs is the capacity of the breadcrumb ring buffer.
 	DefaultMaxBreadcrumbs = 64
@@ -52,11 +66,40 @@ const (
 	// DefaultTabWidth is reported to the Backtrace UI for source rendering.
 	DefaultTabWidth = 8
 
-	// DefaultFlushTimeout bounds how long panic handlers (ReportPanic,
-	// ReportAndRecoverPanic) wait for delivery before re-panicking or
-	// returning, and how long a panic report retries a full queue.
-	// (FinishSendingReports uses the larger DefaultTimeout.)
+	// DefaultFlushTimeout bounds how long ReportPanic (and the package-
+	// level ReportPanicValueAndFlush) waits for capture plus delivery
+	// before re-panicking or returning. ReportAndRecoverPanic does not
+	// wait for delivery.
 	DefaultFlushTimeout = 5 * time.Second
+
+	// DefaultMaxStackBytes caps the raw goroutine dump size.
+	DefaultMaxStackBytes = 4 << 20
+
+	// DefaultMaxReportBytes caps the serialized JSON report.
+	DefaultMaxReportBytes = 8 << 20
+
+	// DefaultMaxAttachments caps the number of attachments per report.
+	DefaultMaxAttachments = 16
+
+	// maxQueueSize is a sanity ceiling for explicit queue sizes.
+	maxQueueSize = 1 << 20
+)
+
+// Byte budgets for source and attachment capture.
+const (
+	// DefaultMaxSourceFileBytes caps a single source file read.
+	DefaultMaxSourceFileBytes int64 = 2 << 20
+
+	// DefaultMaxSourceBytes caps the total source text embedded in one
+	// report.
+	DefaultMaxSourceBytes int64 = 4 << 20
+
+	// DefaultMaxAttachmentBytes caps one attachment.
+	DefaultMaxAttachmentBytes int64 = 10 << 20
+
+	// DefaultMaxTotalAttachmentBytes caps the aggregate attachment bytes
+	// of one report.
+	DefaultMaxTotalAttachmentBytes int64 = 25 << 20
 )
 
 // Environment variables consulted when the corresponding Config field is empty.
@@ -67,6 +110,10 @@ const (
 
 // Config configures a Client. The zero value is not usable: Endpoint is
 // required (directly or via the BACKTRACE_ENDPOINT environment variable).
+//
+// NewClient clones every top-level map and slice, so the caller may reuse or
+// mutate the Config afterwards. Values stored INSIDE attribute maps are
+// retained as given and must not be mutated concurrently with reporting.
 type Config struct {
 	// Endpoint is the Backtrace submission URL. Two forms are supported:
 	//
@@ -86,8 +133,14 @@ type Config struct {
 	// not just the calling goroutine's.
 	CaptureAllGoroutines bool
 
-	// SourceCode controls source code embedding. Default: SourceCodeContext.
+	// SourceCode controls source embedding. Default: SourceCodeMetadata
+	// (path/line only — no source text leaves the host). Embedding
+	// source text is opt-in via SourceCodeContext or SourceCodeFile.
 	SourceCode SourceCodeMode
+
+	// SourceRoots, when non-empty, restricts source text reads (context
+	// and file modes) to files under the listed directory roots.
+	SourceRoots []string
 
 	// ContextLineCount is the number of lines captured above and below a
 	// frame's line in SourceCodeContext mode. Default: 8.
@@ -112,29 +165,38 @@ type Config struct {
 	// of environment variable name patterns whose values are redacted.
 	ScrubEnvVars []string
 
+	// SendMachineID includes a stable machine identifier (the "guid"
+	// attribute) with every report. Default false: stable hardware
+	// identifiers are privacy-sensitive and opt-in.
+	SendMachineID bool
+
 	// AttachmentPaths lists files attached to every report (multipart
 	// submission, one "attachment_<basename>" part per file). Unreadable
-	// or non-regular files and files larger than 10 MiB are skipped with
-	// a debug log. Per-report changes can be made in BeforeSend via
-	// ReportData.Attachments.
+	// or non-regular files and files over the per-file/aggregate budgets
+	// are skipped with a debug log. Per-report changes can be made in
+	// BeforeSend via ReportData.Attachments.
 	AttachmentPaths []string
 
 	// SampleRate is the fraction of reports actually sent, in [0.0, 1.0].
 	// The zero value means 1.0 (send everything), so an uninitialized
-	// Config never silently drops reports.
+	// Config never silently drops reports. Explicit values outside
+	// [0, 1], NaN, and infinities are rejected by NewClient.
 	SampleRate float64
 
 	// BeforeSend, when set, runs just before a report is serialized.
 	// Return the (optionally modified) report to send it, or nil to drop
 	// it. Runs on the SDK's worker goroutine — do not call Flush or Close
 	// from inside the hook. A panic inside the hook is recovered and the
-	// report is DROPPED (never sent half-scrubbed) and counted in
-	// DroppedReports.
+	// report is DROPPED (never sent half-scrubbed) and counted in Stats.
 	BeforeSend func(report *ReportData) *ReportData
 
-	// MaxErrorDepth caps error-chain unwrapping. Default: 100. Negative
-	// disables chain capture.
+	// MaxErrorDepth caps error-graph unwrapping depth. Default: 32.
+	// Negative disables chain capture.
 	MaxErrorDepth int
+
+	// MaxErrorNodes caps the total number of errors captured from one
+	// error graph (relevant for errors.Join trees). Default: 100.
+	MaxErrorNodes int
 
 	// MaxBreadcrumbs caps the breadcrumb ring buffer. Default: 64.
 	// Negative disables breadcrumbs.
@@ -143,28 +205,59 @@ type Config struct {
 	// QueueSize is the report queue capacity. Default: 128.
 	QueueSize int
 
-	// Timeout is the per-request HTTP timeout. Default: 30s.
+	// Timeout is the per-request submission deadline, enforced with an
+	// SDK-owned request context (it applies to custom HTTPClients too).
+	// Default: 30s.
 	Timeout time.Duration
 
-	// HTTPClient overrides the HTTP client used for submission. When set,
-	// Timeout is not applied to it; configure the client yourself.
+	// ShutdownTimeout bounds Close. Default: 5s.
+	ShutdownTimeout time.Duration
+
+	// HTTPClient overrides the HTTP client used for submission. Requests
+	// still carry the SDK's per-request context deadline (Timeout).
+	// Cancellation is cooperative: a custom Transport/RoundTripper that
+	// ignores the request context cannot be forcefully terminated by the
+	// SDK and can hold the worker (and Close) past its deadline.
 	HTTPClient *http.Client
 
-	// DisableMachineAttributes skips the exec-based collection of machine
-	// metadata (CPU model, OS version, machine GUID). Useful in minimal
-	// containers without a shell.
+	// Resource budgets; zero values use the documented defaults.
+	MaxStackBytes           int   // raw goroutine dump cap (default 4 MiB)
+	MaxSourceFileBytes      int64 // single source file read cap (default 2 MiB)
+	MaxSourceBytes          int64 // total embedded source per report (default 4 MiB)
+	MaxReportBytes          int   // serialized JSON report cap (default 8 MiB)
+	MaxAttachments          int   // attachments per report (default 16); negative disables attachments
+	MaxAttachmentBytes      int64 // one attachment (default 10 MiB)
+	MaxTotalAttachmentBytes int64 // aggregate attachments per report (default 25 MiB)
+
+	// DisableMachineAttributes skips collection of machine metadata
+	// (CPU model, OS version).
 	DisableMachineAttributes bool
 
-	// Debug enables SDK diagnostic logging (report payloads, delivery
-	// errors, drops). The SDK never panics regardless of this setting.
+	// Debug enables SDK diagnostic logging: compact, payload-free
+	// summaries (event ID, type, byte counts, redacted destination,
+	// outcome). Report payloads are never logged. The SDK never panics
+	// regardless of this setting.
 	Debug bool
 
 	// Logger receives diagnostic output when Debug is on.
 	// Default: log.New(os.Stderr, "[backtrace] ", log.LstdFlags).
+	// A panicking Logger is contained and cannot crash the application.
+	// A Logger that calls back into the SDK (a logging-adapter pattern)
+	// is also contained: while a diagnostic line is being written, nested
+	// diagnostics for the same client are suppressed to break recursion.
 	Logger Logger
 }
 
-// normalize applies defaults and environment fallbacks. It does not mutate c.
+// cloneConfig detaches all top-level collections from caller ownership.
+func cloneConfig(c Config) Config {
+	c.Attributes = cloneAnyMap(c.Attributes)
+	c.ScrubEnvVars = cloneStringSlice(c.ScrubEnvVars)
+	c.AttachmentPaths = cloneStringSlice(c.AttachmentPaths)
+	c.SourceRoots = cloneStringSlice(c.SourceRoots)
+	return c
+}
+
+// normalize applies defaults to zero values only. It does not mutate c.
 func (c Config) normalize() Config {
 	if c.Endpoint == "" {
 		c.Endpoint = os.Getenv(envEndpoint)
@@ -173,52 +266,127 @@ func (c Config) normalize() Config {
 		c.Token = os.Getenv(envToken)
 	}
 	if c.SourceCode == "" {
-		c.SourceCode = SourceCodeContext
+		c.SourceCode = SourceCodeMetadata
 	}
-	if c.ContextLineCount <= 0 {
+	if c.ContextLineCount == 0 {
 		c.ContextLineCount = DefaultContextLineCount
 	}
-	if c.TabWidth <= 0 {
+	if c.TabWidth == 0 {
 		c.TabWidth = DefaultTabWidth
 	}
-	if c.SampleRate <= 0 {
+	if c.SampleRate == 0 {
 		// Zero value means "send everything" so that a Config that never
 		// mentions sampling behaves as expected.
-		c.SampleRate = 1.0
-	}
-	if c.SampleRate > 1 {
 		c.SampleRate = 1.0
 	}
 	if c.MaxErrorDepth == 0 {
 		c.MaxErrorDepth = DefaultMaxErrorDepth
 	}
+	if c.MaxErrorNodes == 0 {
+		c.MaxErrorNodes = DefaultMaxErrorNodes
+	}
 	if c.MaxBreadcrumbs == 0 {
 		c.MaxBreadcrumbs = DefaultMaxBreadcrumbs
 	}
-	if c.QueueSize <= 0 {
+	if c.QueueSize == 0 {
 		c.QueueSize = DefaultQueueSize
 	}
-	if c.Timeout <= 0 {
+	if c.Timeout == 0 {
 		c.Timeout = DefaultTimeout
+	}
+	if c.ShutdownTimeout == 0 {
+		c.ShutdownTimeout = DefaultShutdownTimeout
+	}
+	if c.MaxStackBytes == 0 {
+		c.MaxStackBytes = DefaultMaxStackBytes
+	}
+	if c.MaxSourceFileBytes == 0 {
+		c.MaxSourceFileBytes = DefaultMaxSourceFileBytes
+	}
+	if c.MaxSourceBytes == 0 {
+		c.MaxSourceBytes = DefaultMaxSourceBytes
+	}
+	if c.MaxReportBytes == 0 {
+		c.MaxReportBytes = DefaultMaxReportBytes
+	}
+	if c.MaxAttachments == 0 {
+		c.MaxAttachments = DefaultMaxAttachments
+	}
+	if c.MaxAttachmentBytes == 0 {
+		c.MaxAttachmentBytes = DefaultMaxAttachmentBytes
+	}
+	if c.MaxTotalAttachmentBytes == 0 {
+		c.MaxTotalAttachmentBytes = DefaultMaxTotalAttachmentBytes
 	}
 	return c
 }
 
-// validate checks that the endpoint is usable. Called with a normalized config.
+// validate rejects invalid explicit values rather than silently repairing
+// them. Called with a normalized config.
 func (c Config) validate() error {
 	if c.Endpoint == "" {
 		return errors.New("bt: Config.Endpoint is required (or set BACKTRACE_ENDPOINT)")
 	}
+	if math.IsNaN(c.SampleRate) || math.IsInf(c.SampleRate, 0) ||
+		c.SampleRate < 0 || c.SampleRate > 1 {
+		return fmt.Errorf("bt: Config.SampleRate must be finite and in [0,1], got %v", c.SampleRate)
+	}
+	if c.QueueSize < 1 || c.QueueSize > maxQueueSize {
+		return fmt.Errorf("bt: Config.QueueSize must be in [1,%d], got %d", maxQueueSize, c.QueueSize)
+	}
+	if c.Timeout <= 0 || c.ShutdownTimeout <= 0 {
+		return errors.New("bt: Config.Timeout and Config.ShutdownTimeout must be positive")
+	}
+	if c.ContextLineCount < 0 || c.TabWidth < 1 {
+		return errors.New("bt: Config.ContextLineCount must be >= 0 and Config.TabWidth >= 1")
+	}
+	if c.MaxErrorNodes < 1 || c.MaxStackBytes < 1 || c.MaxReportBytes < 1 ||
+		c.MaxSourceFileBytes < 1 || c.MaxSourceBytes < 1 ||
+		c.MaxAttachmentBytes < 1 || c.MaxTotalAttachmentBytes < 1 {
+		return errors.New("bt: one or more resource limits are invalid (must be positive)")
+	}
+	if c.MaxAttachmentBytes > c.MaxTotalAttachmentBytes {
+		return errors.New("bt: Config.MaxAttachmentBytes exceeds MaxTotalAttachmentBytes")
+	}
+	switch c.SourceCode {
+	case SourceCodeMetadata, SourceCodeContext, SourceCodeFile, SourceCodeNone:
+	default:
+		return fmt.Errorf("bt: unknown Config.SourceCode mode %q", c.SourceCode)
+	}
+
 	u, err := url.Parse(c.Endpoint)
 	if err != nil {
-		return fmt.Errorf("bt: invalid Config.Endpoint: %w", err)
+		// Do not wrap err: *url.Error quotes the complete raw URL,
+		// which may embed a token, and NewClient errors flow into
+		// user logs. Surface only the inner reason plus the redacted
+		// endpoint — and only when the inner reason itself carries no
+		// quoted input fragment (net/url embeds offending substrings,
+		// e.g. invalid ports, inside double quotes).
+		msg := "unparsable URL"
+		var ue *url.Error
+		if errors.As(err, &ue) && ue.Err != nil {
+			if inner := ue.Err.Error(); !strings.Contains(inner, `"`) {
+				msg = inner
+			}
+		}
+		return fmt.Errorf("bt: invalid Config.Endpoint (%s), got %q", msg, redactURL(c.Endpoint))
 	}
 	if u.Scheme != "http" && u.Scheme != "https" {
 		// Redact the endpoint in errors: it may embed a token, and
 		// NewClient errors flow into user logs.
 		return fmt.Errorf("bt: Config.Endpoint must be an http(s) URL, got %q", redactURL(c.Endpoint))
 	}
-	if c.Token != "" && u.RawQuery != "" {
+	if u.Host == "" || u.Opaque != "" {
+		return fmt.Errorf("bt: Config.Endpoint must be an absolute URL with a host, got %q", redactURL(c.Endpoint))
+	}
+	if u.User != nil {
+		return errors.New("bt: Config.Endpoint must not contain URL userinfo")
+	}
+	if u.Fragment != "" {
+		return errors.New("bt: Config.Endpoint must not contain a fragment")
+	}
+	if c.Token != "" && u.RawQuery != "" &&
+		!strings.EqualFold(u.Hostname(), "submit.backtrace.io") {
 		return fmt.Errorf("bt: Config.Endpoint must not carry a query string when Token is set, got %q", redactURL(c.Endpoint))
 	}
 	return nil
@@ -246,4 +414,19 @@ func (c Config) submissionURL() string {
 	// Trim trailing slashes (the form users paste from a browser) so the
 	// appended path never produces "//post".
 	return fmt.Sprintf("%s/post?%s", strings.TrimRight(c.Endpoint, "/"), v.Encode())
+}
+
+// multipartLimits carries the attachment budgets into the transport.
+type multipartLimits struct {
+	maxAttachments     int
+	maxAttachmentBytes int64
+	maxTotalBytes      int64
+}
+
+func (c Config) attachmentLimits() multipartLimits {
+	return multipartLimits{
+		maxAttachments:     c.MaxAttachments,
+		maxAttachmentBytes: c.MaxAttachmentBytes,
+		maxTotalBytes:      c.MaxTotalAttachmentBytes,
+	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,9 @@
 package bt
 
 import (
+	"errors"
+	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -9,8 +12,8 @@ import (
 func TestConfigNormalizeDefaults(t *testing.T) {
 	cfg := Config{Endpoint: "http://example.com"}.normalize()
 
-	if cfg.SourceCode != SourceCodeContext {
-		t.Errorf("SourceCode = %q, want context", cfg.SourceCode)
+	if cfg.SourceCode != SourceCodeMetadata {
+		t.Errorf("SourceCode = %q, want metadata (production-safe default)", cfg.SourceCode)
 	}
 	if cfg.ContextLineCount != DefaultContextLineCount {
 		t.Errorf("ContextLineCount = %d", cfg.ContextLineCount)
@@ -113,23 +116,83 @@ func TestConfigValidateRejectsQueryWithToken(t *testing.T) {
 		t.Error("endpoint with query + token accepted; submissionURL would be malformed")
 	}
 	// Without a token the endpoint is used verbatim, so a query is fine.
-	if err := (Config{Endpoint: "https://host/post?format=json&token=t"}).validate(); err != nil {
+	if err := (Config{Endpoint: "https://host/post?format=json&token=t"}).normalize().validate(); err != nil {
 		t.Errorf("verbatim endpoint with query rejected: %v", err)
 	}
 }
 
 func TestConfigValidate(t *testing.T) {
+	valid := func(mutate func(*Config)) Config {
+		c := Config{Endpoint: "https://submit.backtrace.io/u/t/json"}.normalize()
+		if mutate != nil {
+			mutate(&c)
+		}
+		return c
+	}
+
 	if err := (Config{}).validate(); err == nil {
 		t.Error("empty endpoint accepted")
 	}
-	if err := (Config{Endpoint: "not a url\x7f"}).validate(); err == nil {
+	if err := valid(func(c *Config) { c.Endpoint = "not a url\x7f" }).validate(); err == nil {
 		t.Error("unparsable endpoint accepted")
 	}
-	if err := (Config{Endpoint: "ftp://x"}).validate(); err == nil {
+	if err := valid(func(c *Config) { c.Endpoint = "ftp://x" }).validate(); err == nil {
 		t.Error("non-http scheme accepted")
 	}
-	if err := (Config{Endpoint: "https://submit.backtrace.io/u/t/json"}).validate(); err != nil {
+	if err := valid(nil).validate(); err != nil {
 		t.Errorf("valid endpoint rejected: %v", err)
+	}
+
+	// Strict validation of explicit values (no silent repair).
+	if err := valid(func(c *Config) { c.SampleRate = -0.5 }).validate(); err == nil {
+		t.Error("negative SampleRate accepted")
+	}
+	if err := valid(func(c *Config) { c.SampleRate = 1.5 }).validate(); err == nil {
+		t.Error("SampleRate > 1 accepted")
+	}
+	if err := valid(func(c *Config) { c.SampleRate = math.NaN() }).validate(); err == nil {
+		t.Error("NaN SampleRate accepted")
+	}
+	if err := valid(func(c *Config) { c.QueueSize = -1 }).validate(); err == nil {
+		t.Error("negative QueueSize accepted")
+	}
+	if err := valid(func(c *Config) { c.SourceCode = "everything" }).validate(); err == nil {
+		t.Error("unknown SourceCode mode accepted")
+	}
+	if err := valid(func(c *Config) { c.Endpoint = "http://" }).validate(); err == nil {
+		t.Error("host-less endpoint accepted")
+	}
+	if err := valid(func(c *Config) { c.Endpoint = "https://user:pw@host/x" }).validate(); err == nil {
+		t.Error("endpoint with userinfo accepted")
+	}
+	if err := valid(func(c *Config) { c.Endpoint = "https://host/x#frag" }).validate(); err == nil {
+		t.Error("endpoint with fragment accepted")
+	}
+	if err := valid(func(c *Config) { c.Timeout = -time.Second }).validate(); err == nil {
+		t.Error("negative Timeout accepted")
+	}
+}
+
+// TestValidateNeverLeaksToken pins the credential-redaction contract: even
+// unparsable endpoints (where url.Error — or its inner error — would quote
+// raw URL fragments) must not leak an embedded token through NewClient
+// errors.
+func TestValidateNeverLeaksToken(t *testing.T) {
+	cases := []string{
+		"https://uni.sp.backtrace.io/post?token=SUPERSECRETTOKEN\x7f",
+		"https://uni.sp.backtrace.io/post?token=SUPERSECRETTOKEN\x00",
+		"ht tp://x/post?token=SUPERSECRETTOKEN",
+		"https://host:SUPERSECRETTOKEN/post", // token-like text in port position
+	}
+	for _, endpoint := range cases {
+		_, err := NewClient(Config{Endpoint: endpoint})
+		if err == nil {
+			t.Errorf("endpoint %q accepted", endpoint)
+			continue
+		}
+		if strings.Contains(err.Error(), "SUPERSECRETTOKEN") {
+			t.Errorf("token leaked through NewClient error: %v", err)
+		}
 	}
 }
 
@@ -138,14 +201,42 @@ func TestUnwrapErrorChainDepthCap(t *testing.T) {
 	for i := 1; i < 10; i++ {
 		err = &testWrapErr{msg: string(rune('0' + i)), inner: err}
 	}
-	if got := len(unwrapErrorChain(err, 3)); got != 3 {
-		t.Errorf("depth-capped chain = %d, want 3", got)
+	// Depth 3 admits the root plus three unwrap levels.
+	if got := len(unwrapErrorChain(err, 3, DefaultMaxErrorNodes)); got != 4 {
+		t.Errorf("depth-capped chain = %d, want 4", got)
 	}
-	if got := unwrapErrorChain(err, -1); got != nil {
+	if got := len(unwrapErrorChain(err, DefaultMaxErrorDepth, 2)); got != 2 {
+		t.Errorf("node-capped chain = %d, want 2", got)
+	}
+	if got := unwrapErrorChain(err, -1, DefaultMaxErrorNodes); got != nil {
 		t.Errorf("negative depth should disable capture, got %d", len(got))
 	}
-	if got := unwrapErrorChain(nil, 10); got != nil {
+	if got := unwrapErrorChain(nil, 10, 10); got != nil {
 		t.Error("nil error should produce no chain")
+	}
+}
+
+func TestUnwrapErrorChainJoinAndCycles(t *testing.T) {
+	// errors.Join fan-out is captured with parent/source metadata.
+	a := errors.New("a")
+	b := errors.New("b")
+	joined := errors.Join(a, b)
+	wrapped := fmt.Errorf("outer: %w", joined)
+
+	chain := unwrapErrorChain(wrapped, DefaultMaxErrorDepth, DefaultMaxErrorNodes)
+	if len(chain) != 4 {
+		t.Fatalf("join graph nodes = %d, want 4 (outer, join, a, b)", len(chain))
+	}
+	if chain[2].Source != "errors[0]" || chain[3].Source != "errors[1]" {
+		t.Errorf("join sources = %q, %q", chain[2].Source, chain[3].Source)
+	}
+
+	// A cyclic error graph terminates without exhausting the caps.
+	cyclic := &testWrapErr{msg: "cycle"}
+	cyclic.inner = cyclic
+	got := unwrapErrorChain(cyclic, DefaultMaxErrorDepth, DefaultMaxErrorNodes)
+	if len(got) != 1 {
+		t.Errorf("cyclic graph nodes = %d, want 1", len(got))
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,8 @@
+package bt
+
+import "errors"
+
+// ErrUnsupportedPlatform is returned (wrapped) by operations that have no
+// implementation on the current platform, such as tracer snapshot upload on
+// macOS or process-tracing setup outside Linux. Test with errors.Is.
+var ErrUnsupportedPlatform = errors.New("bt: operation unsupported on this platform")

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -2,6 +2,7 @@ package bt
 
 import (
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"testing"
 )
@@ -35,19 +36,30 @@ func FuzzBuildThreads(f *testing.F) {
 	})
 }
 
-// FuzzRedactURL: whatever the input, no query token value or userinfo
-// password may survive into the output.
+// FuzzRedactURL: when the input PARSES as a URL whose token query value or
+// userinfo password contains the canary, the canary must not survive into
+// the output. (Raw substring matching would misfire on inputs like a bare
+// "token=X" that have no URL credential semantics.)
 func FuzzRedactURL(f *testing.F) {
 	f.Add("https://uni.sp.backtrace.io/post?format=json&token=SECRETCANARY")
 	f.Add("https://submit.backtrace.io/universe/SECRETCANARY/json")
 	f.Add("https://user:SECRETCANARY@host/path")
 	f.Add("http://%zz")
 	f.Fuzz(func(t *testing.T, raw string) {
-		out := redactURL(raw)
-		if strings.Contains(raw, "SECRETCANARY") &&
-			strings.Contains(out, "SECRETCANARY") &&
-			(strings.Contains(raw, "token=SECRETCANARY") ||
-				strings.Contains(raw, ":SECRETCANARY@")) {
+		out := redactURL(raw) // must never panic
+		u, err := neturl.Parse(raw)
+		if err != nil {
+			// Unparsable input degrades to a fixed placeholder.
+			if out != "[REDACTED URL]" {
+				t.Fatalf("unparsable URL leaked: %q -> %q", raw, out)
+			}
+			return
+		}
+		credential := strings.Contains(u.Query().Get("token"), "SECRETCANARY")
+		if pw, set := u.User.Password(); set && strings.Contains(pw, "SECRETCANARY") {
+			credential = true
+		}
+		if credential && strings.Contains(out, "SECRETCANARY") {
 			t.Fatalf("credential survived redaction: %q -> %q", raw, out)
 		}
 	})

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,106 @@
+package bt
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func newRetryAfterResponse(value string) *http.Response {
+	h := http.Header{}
+	if value != "" {
+		h.Set("Retry-After", value)
+	}
+	return &http.Response{Header: h}
+}
+
+// FuzzBuildThreads exercises the stack parser with arbitrary input: it must
+// never panic and never read source text in metadata mode.
+func FuzzBuildThreads(f *testing.F) {
+	f.Add(stackFixture)
+	f.Add("goroutine 1 [running]:\nmain.main()\n\tC:/x/y.go:42 +0x1f\n")
+	f.Add("...additional frames elided...\n\n[originating from goroutine 3]:\n")
+	f.Add("goroutine running on other thread; stack unavailable\n")
+	f.Add("panic({0x1?, 0x2?})\n\tx:1\n")
+	f.Fuzz(func(t *testing.T, stack string) {
+		threads, sources, _ := buildThreads([]byte(stack), sourceOptions{
+			mode: SourceCodeMetadata, contextLines: 4, tabWidth: 8,
+		})
+		for _, sc := range sources {
+			if sc.Text != "" {
+				t.Fatalf("metadata mode produced source text: %q", sc.Text)
+			}
+		}
+		_ = threads
+	})
+}
+
+// FuzzRedactURL: whatever the input, no query token value or userinfo
+// password may survive into the output.
+func FuzzRedactURL(f *testing.F) {
+	f.Add("https://uni.sp.backtrace.io/post?format=json&token=SECRETCANARY")
+	f.Add("https://submit.backtrace.io/universe/SECRETCANARY/json")
+	f.Add("https://user:SECRETCANARY@host/path")
+	f.Add("http://%zz")
+	f.Fuzz(func(t *testing.T, raw string) {
+		out := redactURL(raw)
+		if strings.Contains(raw, "SECRETCANARY") &&
+			strings.Contains(out, "SECRETCANARY") &&
+			(strings.Contains(raw, "token=SECRETCANARY") ||
+				strings.Contains(raw, ":SECRETCANARY@")) {
+			t.Fatalf("credential survived redaction: %q -> %q", raw, out)
+		}
+	})
+}
+
+// FuzzRetryAfter: arbitrary header values must produce a bounded,
+// non-negative pause.
+func FuzzRetryAfter(f *testing.F) {
+	f.Add("30")
+	f.Add("2147483647")
+	f.Add("-5")
+	f.Add("Wed, 21 Oct 2015 07:28:00 GMT")
+	f.Add("garbage")
+	f.Fuzz(func(t *testing.T, header string) {
+		resp := newRetryAfterResponse(header)
+		d := retryAfter(resp)
+		if d < 0 || d > rateLimitMaxPause {
+			t.Fatalf("retryAfter(%q) = %v, outside [0, %v]", header, d, rateLimitMaxPause)
+		}
+	})
+}
+
+// FuzzSplitQualifiedFunction must never panic and never lose the input.
+func FuzzSplitQualifiedFunction(f *testing.F) {
+	f.Add("testing.(*T).Run(0x1, {0x2, 0x9}, 0x3)")
+	f.Add("pkg.(*Cache[go.shape.string]).Get(0x1)")
+	f.Add("panic({0x1?, 0x2?})")
+	f.Add("noDots")
+	f.Add("[[[[")
+	f.Fuzz(func(t *testing.T, line string) {
+		lib, fn := splitQualifiedFunction(line)
+		_ = lib
+		_ = fn
+	})
+}
+
+// FuzzSafeMultipartName: outputs must be non-empty and free of control
+// characters, quotes, and separators that could corrupt multipart framing.
+func FuzzSafeMultipartName(f *testing.F) {
+	f.Add("/var/log/app.log")
+	f.Add("/tmp/evil\r\nname\x00\"")
+	f.Add("")
+	f.Add("..")
+	f.Fuzz(func(t *testing.T, path string) {
+		name := safeMultipartName(path)
+		if name == "" {
+			t.Fatal("empty multipart name")
+		}
+		if strings.ContainsAny(name, "\r\n\x00\"\\") {
+			t.Fatalf("unsafe characters survived: %q", name)
+		}
+		if len(name) > maxMultipartNameLength {
+			t.Fatalf("name too long: %d", len(name))
+		}
+	})
+}

--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package bt
 import (
 	"log"
 	"os"
+	"sync/atomic"
 )
 
 // Logger is the minimal logging interface used for SDK diagnostics.
@@ -21,6 +22,14 @@ var defaultDiagLogger Logger = log.New(os.Stderr, "[backtrace] ", log.LstdFlags)
 type diag struct {
 	logger Logger
 	debug  bool
+
+	// busy, when set, is a per-client re-entrancy guard: a Logger that
+	// calls back into the SDK (a logging-adapter pattern) would otherwise
+	// recurse Printf -> Report -> drop -> logf -> Printf without bound,
+	// ending in an uncatchable stack overflow. While a diagnostic line is
+	// being written, nested (and concurrent) diagnostics for the same
+	// client are suppressed.
+	busy *atomic.Int32
 }
 
 func (d diag) logf(format string, v ...interface{}) {
@@ -31,5 +40,17 @@ func (d diag) logf(format string, v ...interface{}) {
 	if l == nil {
 		l = defaultDiagLogger
 	}
+
+	if d.busy != nil {
+		if !d.busy.CompareAndSwap(0, 1) {
+			return
+		}
+		defer d.busy.Store(0)
+	}
+
+	// A diagnostic callback must never be able to terminate the
+	// application or the SDK worker. Do not recursively attempt to log
+	// this panic.
+	defer func() { _ = recover() }()
 	l.Printf(format, v...)
 }

--- a/main.go
+++ b/main.go
@@ -25,6 +25,13 @@
 // Configure Options before the first report. For runtime attribute changes
 // use SetAttribute (safe for concurrent use) instead of mutating
 // Options.Attributes.
+//
+// # Scope
+//
+// This SDK reports errors, messages, and recovered panics from within the
+// process. It cannot capture crashes that bypass Go panics (native/cgo
+// faults, runtime aborts); for those, use the bcd out-of-process tracer
+// integration in this package or the Backtrace Coresnap workflow.
 package bt
 
 import (
@@ -54,43 +61,53 @@ type OptionsStruct struct {
 	// Attributes are added to every report. Prefer SetAttribute for
 	// changes made while the application is running.
 	Attributes map[string]interface{}
-	// DebugBacktrace enables SDK diagnostic logging. Unlike historical
-	// versions, the SDK never panics: failures are logged instead.
+	// DebugBacktrace enables SDK diagnostic logging (payload-free
+	// summaries). Unlike historical versions, the SDK never panics:
+	// failures are logged instead.
 	DebugBacktrace bool
 
 	// SourceCode controls source embedding; see Config.SourceCode.
-	// Default: SourceCodeContext (historical behavior was whole files;
-	// opt back in with SourceCodeFile).
+	// Default: SourceCodeMetadata (path/line only). Historical behavior
+	// (whole files) is available with SourceCodeFile.
 	SourceCode SourceCodeMode
+	// SourceRoots restricts source text reads; see Config.SourceRoots.
+	SourceRoots []string
 	// SampleRate is the fraction of reports sent; zero means 1.0.
 	SampleRate float64
 	// BeforeSend runs before each report is serialized; see Config.BeforeSend.
 	BeforeSend func(report *ReportData) *ReportData
 	// ScrubEnvVars extends the built-in redaction patterns; see Config.ScrubEnvVars.
 	ScrubEnvVars []string
+	// SendMachineID includes a stable machine identifier; see
+	// Config.SendMachineID. Default false.
+	SendMachineID bool
 	// Logger receives diagnostics when DebugBacktrace is on.
 	Logger Logger
 	// HTTPClient overrides the submission HTTP client.
 	HTTPClient *http.Client
-	// Timeout is the per-request HTTP timeout (default 30s). Applied when
-	// the default client is created (first report).
+	// Timeout is the per-request submission deadline (default 30s).
+	// Applied when the default client is created (first report).
 	Timeout time.Duration
+	// ShutdownTimeout bounds client shutdown; see Config.ShutdownTimeout.
+	ShutdownTimeout time.Duration
 	// QueueSize is the report queue capacity (default 128). Applied when
 	// the default client is created (first report).
 	QueueSize int
-	// MaxErrorDepth caps error-chain unwrapping; see Config.MaxErrorDepth.
+	// MaxErrorDepth caps error-graph unwrapping; see Config.MaxErrorDepth.
 	MaxErrorDepth int
 	// MaxBreadcrumbs caps the breadcrumb buffer; applied at first report.
 	MaxBreadcrumbs int
 	// AttachmentPaths lists files attached to every report.
 	AttachmentPaths []string
-	// DisableMachineAttributes skips exec-based machine metadata collection.
+	// DisableMachineAttributes skips machine metadata collection.
 	DisableMachineAttributes bool
 }
 
 // Options configures the legacy global reporter. Set fields before the
 // first report; concurrent mutation while reporting is not synchronized
-// (use SetAttribute / SetAttributes for runtime attribute updates).
+// (use SetAttribute / SetAttributes for runtime attribute updates). The
+// delivery configuration is snapshotted when each report is captured, so
+// later changes cannot reroute already-queued reports.
 var Options OptionsStruct
 
 func init() {
@@ -103,13 +120,11 @@ func init() {
 // alongside the legacy global API.
 var legacyAttrMu sync.Mutex
 
-// optionsToConfig snapshots the global Options into a Config.
+// optionsToConfig snapshots the global Options into a Config, cloning every
+// collection so queued reports cannot observe later mutations.
 func optionsToConfig() Config {
 	legacyAttrMu.Lock()
-	attrs := make(map[string]interface{}, len(Options.Attributes))
-	for k, v := range Options.Attributes {
-		attrs[k] = v
-	}
+	attrs := cloneAnyMap(Options.Attributes)
 	legacyAttrMu.Unlock()
 
 	return Config{
@@ -122,16 +137,19 @@ func optionsToConfig() Config {
 		Attributes:               attrs,
 		Debug:                    Options.DebugBacktrace,
 		SourceCode:               Options.SourceCode,
+		SourceRoots:              cloneStringSlice(Options.SourceRoots),
 		SampleRate:               Options.SampleRate,
 		BeforeSend:               Options.BeforeSend,
-		ScrubEnvVars:             Options.ScrubEnvVars,
+		ScrubEnvVars:             cloneStringSlice(Options.ScrubEnvVars),
+		SendMachineID:            Options.SendMachineID,
 		Logger:                   Options.Logger,
 		HTTPClient:               Options.HTTPClient,
 		Timeout:                  Options.Timeout,
+		ShutdownTimeout:          Options.ShutdownTimeout,
 		QueueSize:                Options.QueueSize,
 		MaxErrorDepth:            Options.MaxErrorDepth,
 		MaxBreadcrumbs:           Options.MaxBreadcrumbs,
-		AttachmentPaths:          Options.AttachmentPaths,
+		AttachmentPaths:          cloneStringSlice(Options.AttachmentPaths),
 		DisableMachineAttributes: Options.DisableMachineAttributes,
 	}.normalize()
 }
@@ -139,27 +157,46 @@ func optionsToConfig() Config {
 var (
 	defaultClientMu sync.Mutex
 	defaultClientV  *Client
+
+	// disabledWarnOnce rate-limits the unconditional misconfiguration
+	// warning to a single line per process.
+	disabledWarnOnce sync.Once
 )
 
 // defaultClient lazily creates the client backing the legacy global API.
-// Returns nil while Options.Endpoint (and BACKTRACE_ENDPOINT) are unset:
-// the global API is then a safe no-op.
+// Returns nil while Options.Endpoint (and BACKTRACE_ENDPOINT) are unset or
+// invalid: the global API is then a safe no-op.
 func defaultClient() *Client {
 	defaultClientMu.Lock()
-	defer defaultClientMu.Unlock()
 	if defaultClientV != nil {
-		return defaultClientV
+		c := defaultClientV
+		defaultClientMu.Unlock()
+		return c
 	}
 	cfg := optionsToConfig()
 	if err := cfg.validate(); err != nil {
-		diag{logger: Options.Logger, debug: Options.DebugBacktrace}.logf("reporting disabled: %v", err)
+		defaultClientMu.Unlock()
+		// Log outside the lock: the logger is application code.
+		diag{logger: cfg.Logger, debug: cfg.Debug}.logf("reporting disabled: %v", err)
+		// An endpoint was configured but rejected: the application
+		// clearly intended reporting, so surface the misconfiguration
+		// once even without debug mode (an empty endpoint stays
+		// silent — that is the documented no-op mode).
+		if cfg.Endpoint != "" {
+			disabledWarnOnce.Do(func() {
+				defaultDiagLogger.Printf("reporting disabled: %v", err)
+			})
+		}
 		return nil
 	}
 	// The legacy client re-reads Options on every report so historical
 	// patterns (mutating bt.Options at runtime) keep working; queue size,
-	// timeout, and HTTP client are fixed at creation.
-	defaultClientV = startClient(optionsToConfig)
-	return defaultClientV
+	// timeout, and HTTP client are fixed at creation, and each report
+	// snapshots the delivery configuration at capture time.
+	c := startClient(optionsToConfig)
+	defaultClientV = c
+	defaultClientMu.Unlock()
+	return c
 }
 
 // Report sends an error report through the legacy global reporter. object
@@ -172,41 +209,77 @@ func Report(object interface{}, extraAttributes map[string]interface{}) {
 	}
 }
 
+// reportingConfigured decides whether the deferred panic helpers should act
+// WITHOUT instantiating the default client — the helpers run on every
+// deferred return, and client startup belongs on the (rare) panic path.
+func reportingConfigured() bool {
+	if currentDefaultClient() != nil {
+		return true
+	}
+	return optionsToConfig().validate() == nil
+}
+
 // ReportPanic reports a panic and re-panics with the original value, after
-// waiting up to DefaultFlushTimeout for delivery. Use with defer:
+// waiting up to DefaultFlushTimeout (one deadline covering capture and
+// delivery). Use with defer:
 //
 //	defer bt.ReportPanic(nil)
+//
+// While the SDK is unconfigured this function does NOT recover: the
+// original panic proceeds exactly as if the handler were absent.
 func ReportPanic(extraAttributes map[string]interface{}) {
+	if !reportingConfigured() {
+		// Crucial: do not call recover. The original panic continues
+		// exactly as it did before SDK configuration.
+		return
+	}
 	v := recover()
 	if v == nil {
 		return
 	}
 	if c := defaultClient(); c != nil {
-		c.ReportPanicValue(v, extraAttributes)
-		c.Flush(DefaultFlushTimeout)
+		_ = c.ReportPanicValueAndFlush(v, extraAttributes, DefaultFlushTimeout)
 	}
 	panic(v)
 }
 
 // ReportAndRecoverPanic reports a panic and swallows it; the goroutine
-// lives on. Use with defer.
+// lives on. Use with defer. While the SDK is unconfigured this function
+// does NOT recover: the original panic proceeds unchanged.
 func ReportAndRecoverPanic(extraAttributes map[string]interface{}) {
+	if !reportingConfigured() {
+		return // no recover; preserve the application's panic
+	}
 	v := recover()
 	if v == nil {
 		return
 	}
 	if c := defaultClient(); c != nil {
 		c.ReportPanicValue(v, extraAttributes)
+		return
 	}
+	// Configuration became invalid between the check and client creation
+	// (rare race): keep the panic alive rather than silently swallow it.
+	panic(v)
 }
 
 // ReportPanicValue reports an already-recovered panic value through the
-// legacy global reporter without re-panicking. Intended for middleware and
-// custom recover() handlers.
+// legacy global reporter without re-panicking or blocking. Intended for
+// middleware and custom recover() handlers.
 func ReportPanicValue(value interface{}, extraAttributes map[string]interface{}) {
 	if c := defaultClient(); c != nil {
 		c.ReportPanicValue(value, extraAttributes)
 	}
+}
+
+// ReportPanicValueAndFlush reports an already-recovered panic value and
+// waits for its delivery under one deadline. Returns false when the SDK is
+// unconfigured or delivery did not complete in time.
+func ReportPanicValueAndFlush(value interface{}, extraAttributes map[string]interface{}, timeout time.Duration) bool {
+	if c := defaultClient(); c != nil {
+		return c.ReportPanicValueAndFlush(value, extraAttributes, timeout)
+	}
+	return false
 }
 
 // SetAttribute sets a global attribute included in every subsequent report.
@@ -241,7 +314,8 @@ func AddBreadcrumb(b Breadcrumb) {
 
 // Flush blocks until reports queued at the time of the call are processed
 // or timeout elapses, reporting whether the drain completed. The reporter
-// stays fully usable afterwards.
+// stays fully usable afterwards. Flushing proves local processing and send
+// completion, not backend acceptance.
 func Flush(timeout time.Duration) bool {
 	c := currentDefaultClient()
 	if c == nil {
@@ -251,9 +325,10 @@ func Flush(timeout time.Duration) bool {
 }
 
 // FinishSendingReports blocks until queued reports are sent (bounded by the
-// configured HTTP timeout per report, 30s overall). Unlike historical
-// versions it does NOT stop the reporter: reporting continues to work
-// afterwards. Kept for backward compatibility — new code should use Flush.
+// configured submission deadline per report, 30s overall). Unlike
+// historical versions it does NOT stop the reporter: reporting continues to
+// work afterwards. Kept for backward compatibility — new code should use
+// Flush.
 func FinishSendingReports() {
 	Flush(DefaultTimeout)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -312,6 +312,55 @@ func TestSetAttributeIsConcurrencySafe(t *testing.T) {
 	}
 }
 
+// resetDefaultClientForTest detaches the process-global default client so a
+// test can exercise the unconfigured path, restoring everything afterwards.
+func resetDefaultClientForTest(t *testing.T) {
+	t.Helper()
+	defaultClientMu.Lock()
+	oldClient := defaultClientV
+	defaultClientV = nil
+	defaultClientMu.Unlock()
+	oldOptions := Options
+	t.Cleanup(func() {
+		defaultClientMu.Lock()
+		defaultClientV = oldClient
+		defaultClientMu.Unlock()
+		Options = oldOptions
+	})
+}
+
+// TestUnconfiguredPanicHelpersDoNotRecover pins the legacy semantic: while
+// reporting is unconfigured, the deferred panic helpers must not touch the
+// panic at all — the application's panic proceeds exactly as if the handler
+// were absent.
+func TestUnconfiguredPanicHelpersDoNotRecover(t *testing.T) {
+	resetDefaultClientForTest(t)
+	t.Setenv(envEndpoint, "")
+	t.Setenv(envToken, "")
+	Options.Endpoint = ""
+	Options.Token = ""
+
+	recoverValue := func(f func()) (v interface{}) {
+		defer func() { v = recover() }()
+		f()
+		return nil
+	}
+
+	if got := recoverValue(func() {
+		defer ReportAndRecoverPanic(nil)
+		panic("original")
+	}); got != "original" {
+		t.Fatalf("ReportAndRecoverPanic swallowed an unconfigured panic: recovered %#v, want it to propagate", got)
+	}
+
+	if got := recoverValue(func() {
+		defer ReportPanic(nil)
+		panic("original2")
+	}); got != "original2" {
+		t.Fatalf("ReportPanic altered an unconfigured panic: recovered %#v", got)
+	}
+}
+
 func TestLegacyEnvVarAnnotations(t *testing.T) {
 	legacyServer.reset()
 	t.Setenv("BT_TEST_SECRET_TOKEN", "hunter2")

--- a/put_options.go
+++ b/put_options.go
@@ -1,0 +1,35 @@
+//go:build linux || freebsd || darwin
+
+package bt
+
+import (
+	"net/http"
+	"time"
+)
+
+// PutOptions modifies the behavior of snapshot uploads (Tracer.Put and
+// friends). The zero value uses the documented defaults.
+type PutOptions struct {
+	// If set to true, tracer results (i.e. generated snapshot files)
+	// will be unlinked from the filesystem after successful puts.
+	Unlink bool
+
+	// Deprecated: use HTTPClient. Retained for source compatibility;
+	// ignored when HTTPClient is set.
+	Client http.Client
+
+	// HTTPClient, when set, is used for snapshot uploads. Requests carry
+	// an SDK-owned deadline (Timeout) either way.
+	HTTPClient *http.Client
+
+	// Timeout bounds each snapshot upload. Default: 30s.
+	Timeout time.Duration
+
+	// MaxSnapshotBytes caps the size of an uploaded snapshot file.
+	// Default: 1 GiB.
+	MaxSnapshotBytes int64
+
+	// If set to true, tracer results will be uploaded after each
+	// successful Trace request.
+	OnTrace bool
+}

--- a/report.go
+++ b/report.go
@@ -2,9 +2,13 @@ package bt
 
 import (
 	"crypto/rand"
-	"errors"
+	"crypto/sha256"
 	"fmt"
+	"os"
+	"reflect"
 	"runtime"
+	"sync/atomic"
+	"time"
 )
 
 // ReportData is a fully assembled crash/error report, exposed to the
@@ -20,7 +24,7 @@ type ReportData struct {
 	Timestamp int64
 
 	// Classifiers group the report in the Backtrace UI; the SDK sets
-	// exactly one of "error", "panic", or "message". Error-chain type
+	// exactly one of "error", "panic", or "message". Error-graph type
 	// names are reported via the "error.type" attribute and the
 	// "Error Chain" annotation, not as classifiers.
 	Classifiers []string
@@ -66,42 +70,101 @@ func (r *ReportData) toWire() map[string]interface{} {
 	}
 }
 
-// uuid4 returns an RFC 4122 version 4 UUID from crypto/rand.
+var uuidFallbackCounter atomic.Uint64
+
+// uuid4 returns an RFC 4122 version 4 UUID from crypto/rand. If crypto/rand
+// somehow fails (documented never to happen on supported platforms), the
+// fallback derives distinct bytes from time, PID, and a counter rather than
+// producing a process-wide constant.
 func uuid4() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {
-		// crypto/rand is documented never to fail on supported
-		// platforms; if it somehow does, a constant-free fallback is
-		// still preferable to panicking inside a crash reporter.
-		for i := range b {
-			b[i] = byte(i * 17)
-		}
+		n := uuidFallbackCounter.Add(1)
+		seed := fmt.Sprintf("%d:%d:%d", time.Now().UnixNano(), os.Getpid(), n)
+		sum := sha256.Sum256([]byte(seed))
+		copy(b[:], sum[:16])
 	}
 	b[6] = (b[6] & 0x0f) | 0x40 // version 4
 	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
 	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
-// errorChainLink describes one error in an unwrapped chain.
+// errorChainLink describes one node in an unwrapped error graph.
 type errorChainLink struct {
-	Type    string `json:"type"`
-	Message string `json:"message"`
+	ID       int    `json:"id"`
+	ParentID *int   `json:"parentId,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Type     string `json:"type"`
+	Message  string `json:"message"`
 }
 
-// unwrapErrorChain walks err's Unwrap chain (up to maxDepth links) and
-// returns the chain description (Go type name plus message per link), used
-// for the "error.type" attribute and the "Error Chain" annotation.
-// A maxDepth < 0 disables chain capture.
-func unwrapErrorChain(err error, maxDepth int) []errorChainLink {
-	if err == nil || maxDepth < 0 {
+// unwrapErrorChain walks err's unwrap graph — both Unwrap() error and
+// Unwrap() []error (errors.Join) forms — bounded by depth and total node
+// count, with cycle detection. All application-defined methods are invoked
+// behind panic containment. A maxDepth < 0 disables capture.
+func unwrapErrorChain(err error, maxDepth, maxNodes int) []errorChainLink {
+	if err == nil || maxDepth < 0 || maxNodes < 1 {
 		return nil
 	}
-	var chain []errorChainLink
-	for e := err; e != nil && len(chain) < maxDepth; e = errors.Unwrap(e) {
-		chain = append(chain, errorChainLink{
-			Type:    fmt.Sprintf("%T", e),
-			Message: e.Error(),
+	links := make([]errorChainLink, 0, 8)
+	seen := make(map[string]struct{})
+
+	var visit func(current error, depth int, parent *int, source string)
+	visit = func(current error, depth int, parent *int, source string) {
+		if current == nil || depth > maxDepth || len(links) >= maxNodes {
+			return
+		}
+		key := errorVisitKey(current)
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+
+		id := len(links)
+		links = append(links, errorChainLink{
+			ID:       id,
+			ParentID: parent,
+			Source:   source,
+			Type:     fmt.Sprintf("%T", current),
+			Message:  safeErrorString(current),
 		})
+		parentID := id
+
+		if many := safeUnwrapMany(current); many != nil {
+			for i, child := range many {
+				visit(child, depth+1, &parentID, fmt.Sprintf("errors[%d]", i))
+			}
+			return
+		}
+		visit(safeUnwrapOne(current), depth+1, &parentID, "unwrap")
 	}
-	return chain
+
+	visit(err, 0, nil, "")
+	return links
+}
+
+// errorVisitKey identifies an error for cycle detection: pointer identity
+// where available, type+message otherwise.
+func errorVisitKey(err error) string {
+	rv := reflect.ValueOf(err)
+	if rv.IsValid() && rv.Kind() == reflect.Pointer && !rv.IsNil() {
+		return fmt.Sprintf("%T@%x", err, rv.Pointer())
+	}
+	return fmt.Sprintf("%T:%s", err, safeErrorString(err))
+}
+
+func safeUnwrapOne(err error) (out error) {
+	defer func() { _ = recover() }()
+	if u, ok := err.(interface{ Unwrap() error }); ok {
+		return u.Unwrap()
+	}
+	return nil
+}
+
+func safeUnwrapMany(err error) (out []error) {
+	defer func() { _ = recover() }()
+	if u, ok := err.(interface{ Unwrap() []error }); ok {
+		return append([]error(nil), u.Unwrap()...)
+	}
+	return nil
 }

--- a/safety.go
+++ b/safety.go
@@ -1,0 +1,53 @@
+package bt
+
+import "fmt"
+
+const formattingPanicPlaceholder = "value panicked while being formatted"
+
+// safeSprint is used at every boundary that may execute application-defined
+// String or Format methods. It must never call the diagnostic logger: the
+// logger is application code too.
+func safeSprint(v interface{}) (out string) {
+	defer func() {
+		if recover() != nil {
+			out = fmt.Sprintf("<%T: %s>", v, formattingPanicPlaceholder)
+		}
+	}()
+	return fmt.Sprint(v)
+}
+
+// safeErrorString is the error-specific equivalent of safeSprint. A typed-nil
+// error is a non-nil interface and may panic in Error(); this helper contains
+// that case.
+func safeErrorString(err error) (out string) {
+	if err == nil {
+		return ""
+	}
+	defer func() {
+		if recover() != nil {
+			out = fmt.Sprintf("<%T: Error() panicked>", err)
+		}
+	}()
+	return err.Error()
+}
+
+// cloneStringSlice detaches the slice header from caller ownership.
+func cloneStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	return append([]string(nil), in...)
+}
+
+// cloneAnyMap detaches the map header from caller ownership. Nested reference
+// values are documented as immutable after the reporting call returns.
+func cloneAnyMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,75 @@
+package bt
+
+import "sync/atomic"
+
+// dropReason indexes internalStats.drops. Keep dropReasonCount last.
+type dropReason int
+
+const (
+	dropSampled dropReason = iota
+	dropQueueFull
+	dropClosed
+	dropBeforeSend
+	dropSerialization
+	dropOversize
+	dropRateLimit
+	dropNetwork
+	dropServerReject
+	dropInternal
+	dropReasonCount
+)
+
+// internalStats backs the ClientStats snapshot with lock-free counters.
+type internalStats struct {
+	accepted  atomic.Uint64
+	delivered atomic.Uint64
+	drops     [dropReasonCount]atomic.Uint64
+}
+
+func (s *internalStats) drop(r dropReason) {
+	s.drops[r].Add(1)
+}
+
+func (s *internalStats) droppedTotal() uint64 {
+	var total uint64
+	for i := range s.drops {
+		total += s.drops[i].Load()
+	}
+	return total
+}
+
+// ClientStats is an immutable snapshot of a client's report accounting,
+// broken down by outcome. Accepted counts reports admitted to the queue;
+// Delivered counts successful submissions; the remaining fields count
+// discarded reports by reason.
+type ClientStats struct {
+	Accepted      uint64
+	Delivered     uint64
+	Sampled       uint64
+	QueueFull     uint64
+	Closed        uint64
+	BeforeSend    uint64
+	Serialization uint64
+	Oversize      uint64
+	RateLimited   uint64
+	Network       uint64
+	ServerReject  uint64
+	Internal      uint64
+}
+
+func (s *internalStats) snapshot() ClientStats {
+	return ClientStats{
+		Accepted:      s.accepted.Load(),
+		Delivered:     s.delivered.Load(),
+		Sampled:       s.drops[dropSampled].Load(),
+		QueueFull:     s.drops[dropQueueFull].Load(),
+		Closed:        s.drops[dropClosed].Load(),
+		BeforeSend:    s.drops[dropBeforeSend].Load(),
+		Serialization: s.drops[dropSerialization].Load(),
+		Oversize:      s.drops[dropOversize].Load(),
+		RateLimited:   s.drops[dropRateLimit].Load(),
+		Network:       s.drops[dropNetwork].Load(),
+		ServerReject:  s.drops[dropServerReject].Load(),
+		Internal:      s.drops[dropInternal].Load(),
+	}
+}

--- a/symlink_verify_test.go
+++ b/symlink_verify_test.go
@@ -1,0 +1,36 @@
+package bt
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSymlinkBypassVerify(t *testing.T) {
+	allowedDir := t.TempDir()
+	secretDir := t.TempDir()
+	secret := filepath.Join(secretDir, "secret.go")
+	if err := os.WriteFile(secret, []byte("TOP\nSECRET\nDATA\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// symlink under allowed root pointing to secret outside it
+	link := filepath.Join(allowedDir, "linked.go")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := "goroutine 1 [running]:\n" +
+		"main.a()\n" +
+		"\t" + link + ":2 +0x1\n"
+
+	threads, sources, _ := buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeContext, contextLines: 2, tabWidth: 8,
+		roots: []string{allowedDir},
+	})
+	frames := threads["0"].Stacks
+	got := sources[frames[0].SourceCodeID].Text
+	t.Logf("embedded text via symlink: %q", got)
+	if got != "" {
+		t.Errorf("BYPASS CONFIRMED: symlink leaked target content: %q", got)
+	}
+}

--- a/threads.go
+++ b/threads.go
@@ -1,7 +1,9 @@
 package bt
 
 import (
+	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -43,6 +45,12 @@ type sourceOptions struct {
 	mode         SourceCodeMode
 	contextLines int
 	tabWidth     int
+	// roots, when non-empty, restricts which files may be read.
+	roots []string
+	// maxFileBytes caps a single file read; maxTotal caps the aggregate
+	// source text embedded in one report.
+	maxFileBytes int64
+	maxTotal     int64
 }
 
 // ParseThreadsFromStack parses runtime.Stack output into the Backtrace
@@ -54,6 +62,9 @@ func ParseThreadsFromStack(stackTrace []byte) (map[string]Thread, map[string]Sou
 		mode:         cfg.SourceCode,
 		contextLines: cfg.ContextLineCount,
 		tabWidth:     cfg.TabWidth,
+		roots:        cfg.SourceRoots,
+		maxFileBytes: cfg.MaxSourceFileBytes,
+		maxTotal:     cfg.MaxSourceBytes,
 	})
 	return threads, sourceCodes
 }
@@ -126,7 +137,7 @@ func buildThreads(stackTrace []byte, opts sourceOptions) (map[string]Thread, map
 				continue
 			}
 			qualified := trimCreatedBy(line)
-			if strings.HasPrefix(qualified, sdkFramePrefix) {
+			if isSDKFrame(qualified) {
 				if len(current.Stacks) == 0 {
 					sdkOnly = true
 				}
@@ -215,6 +226,15 @@ func splitQualifiedFunction(line string) (library, function string) {
 	return line[:lastDot], line[lastDot+1:]
 }
 
+// isSDKFrame reports whether a qualified function name belongs to this SDK,
+// requiring an import-path boundary so sibling module paths (e.g.
+// ".../backtrace-go-fork") are never filtered.
+func isSDKFrame(name string) bool {
+	return name == sdkFramePrefix ||
+		strings.HasPrefix(name, sdkFramePrefix+"/") ||
+		strings.HasPrefix(name, sdkFramePrefix+".")
+}
+
 // trimCreatedBy reduces "created by pkg.fn in goroutine 7" to "pkg.fn".
 func trimCreatedBy(line string) string {
 	if strings.HasPrefix(line, "created by") {
@@ -224,17 +244,30 @@ func trimCreatedBy(line string) string {
 	return line
 }
 
-// sourceBuilder deduplicates and extracts source snippets for stack frames.
+// sourceBuilder deduplicates and extracts source snippets for stack frames,
+// under per-file and per-report byte budgets and an optional root allowlist.
 type sourceBuilder struct {
-	opts    sourceOptions
-	ids     map[string]string // dedup key -> snippet ID
-	entries map[string]SourceCode
-	files   map[string][]string // per-report file line cache
-	failed  map[string]bool
-	nextID  int
+	opts      sourceOptions
+	ids       map[string]string // dedup key -> snippet ID
+	entries   map[string]SourceCode
+	files     map[string][]string // per-report file line cache
+	failed    map[string]bool
+	nextID    int
+	usedBytes int64 // embedded source text so far (budget accounting)
 }
 
 func newSourceBuilder(opts sourceOptions) *sourceBuilder {
+	// Normalize roots to absolute paths once: stack traces carry absolute
+	// file paths, so a relative root would silently never match.
+	if len(opts.roots) > 0 {
+		normalized := make([]string, 0, len(opts.roots))
+		for _, root := range opts.roots {
+			if abs, err := filepath.Abs(root); err == nil {
+				normalized = append(normalized, abs)
+			}
+		}
+		opts.roots = normalized
+	}
 	return &sourceBuilder{
 		opts:    opts,
 		ids:     map[string]string{},
@@ -262,7 +295,12 @@ func (b *sourceBuilder) reference(path, lineNo string) string {
 	id := strconv.Itoa(b.nextID)
 	b.nextID++
 	b.ids[key] = id
-	b.entries[id] = b.extract(path, lineNo)
+	if b.opts.mode == SourceCodeMetadata {
+		// Path/line metadata only; no source text leaves the host.
+		b.entries[id] = SourceCode{Path: path}
+	} else {
+		b.entries[id] = b.extract(path, lineNo)
+	}
 	return id
 }
 
@@ -271,19 +309,26 @@ func (b *sourceBuilder) result() map[string]SourceCode {
 }
 
 // extract builds the snippet for path around lineNo according to the mode.
-// Unreadable files degrade to a path-only entry.
+// Unreadable, disallowed, or over-budget files degrade to path-only entries.
 func (b *sourceBuilder) extract(path, lineNo string) SourceCode {
 	sc := SourceCode{Path: path}
+
+	// Short-circuit before reading: once the per-report budget is
+	// exhausted no further file I/O is useful.
+	if b.opts.maxTotal > 0 && b.usedBytes >= b.opts.maxTotal {
+		return sc
+	}
 
 	lines := b.readLines(path)
 	if lines == nil {
 		return sc
 	}
 
+	var text string
+	startLine := 1
 	switch b.opts.mode {
 	case SourceCodeFile:
-		sc.Text = strings.Join(lines, "\n")
-		sc.StartLine = 1
+		text = strings.Join(lines, "\n")
 	default: // SourceCodeContext
 		center, err := strconv.Atoi(lineNo)
 		if err != nil || center < 1 {
@@ -300,17 +345,52 @@ func (b *sourceBuilder) extract(path, lineNo string) SourceCode {
 		if start > len(lines) {
 			return sc
 		}
-		sc.Text = strings.Join(lines[start-1:end], "\n")
-		sc.StartLine = start
+		text = strings.Join(lines[start-1:end], "\n")
+		startLine = start
 	}
 
+	// Enforce the per-report source budget.
+	if b.opts.maxTotal > 0 && b.usedBytes+int64(len(text)) > b.opts.maxTotal {
+		return sc
+	}
+	b.usedBytes += int64(len(text))
+
+	sc.Text = text
+	sc.StartLine = startLine
 	sc.StartColumn = 1
 	sc.StartPos = 0
 	sc.TabWidth = b.opts.tabWidth
 	return sc
 }
 
-// readLines reads and caches a source file for the duration of one report.
+// pathAllowed applies the SourceRoots allowlist: when roots are configured,
+// only files under one of them may be read. Both the candidate and the
+// roots are symlink-resolved so a link placed under an allowed root cannot
+// smuggle in content from outside it; an unresolvable candidate is denied.
+func (b *sourceBuilder) pathAllowed(path string) bool {
+	if len(b.opts.roots) == 0 {
+		return true
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	for _, root := range b.opts.roots {
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			continue
+		}
+		if resolved == resolvedRoot ||
+			strings.HasPrefix(resolved, resolvedRoot+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
+}
+
+// readLines reads and caches a source file for the duration of one report,
+// bounded by the per-file byte budget and restricted to a regular file
+// inside the configured roots.
 func (b *sourceBuilder) readLines(path string) []string {
 	if lines, ok := b.files[path]; ok {
 		return lines
@@ -318,11 +398,35 @@ func (b *sourceBuilder) readLines(path string) []string {
 	if b.failed[path] {
 		return nil
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
+	fail := func() []string {
 		b.failed[path] = true
 		return nil
 	}
+	if !b.pathAllowed(path) {
+		return fail()
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fail()
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return fail()
+	}
+	maxBytes := b.opts.maxFileBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxSourceFileBytes
+	}
+	if info.Size() > maxBytes {
+		return fail()
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
+	if err != nil || int64(len(data)) > maxBytes {
+		return fail()
+	}
+
 	lines := strings.Split(strings.ReplaceAll(string(data), "\r\n", "\n"), "\n")
 	b.files[path] = lines
 	return lines

--- a/threads_test.go
+++ b/threads_test.go
@@ -378,6 +378,113 @@ func TestParseThreadsFromStackLegacyWrapper(t *testing.T) {
 	}
 }
 
+func TestSourceMetadataMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "meta.go")
+	if err := os.WriteFile(path, []byte("secret line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := "goroutine 1 [running]:\n" +
+		"main.main()\n" +
+		"\t" + path + ":1 +0x1f\n"
+
+	threads, sources, _ := buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeMetadata, contextLines: 8, tabWidth: 8,
+	})
+	sc := sources[threads["0"].Stacks[0].SourceCodeID]
+	if sc.Path != path {
+		t.Errorf("metadata path = %q", sc.Path)
+	}
+	if sc.Text != "" {
+		t.Errorf("metadata mode leaked source text: %q", sc.Text)
+	}
+}
+
+func TestSourceRootsAllowlist(t *testing.T) {
+	allowedDir := t.TempDir()
+	deniedDir := t.TempDir()
+	allowed := filepath.Join(allowedDir, "in.go")
+	denied := filepath.Join(deniedDir, "out.go")
+	for _, p := range []string{allowed, denied} {
+		if err := os.WriteFile(p, []byte("one\ntwo\nthree\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stack := "goroutine 1 [running]:\n" +
+		"main.a()\n" +
+		"\t" + allowed + ":2 +0x1\n" +
+		"main.b()\n" +
+		"\t" + denied + ":2 +0x2\n"
+
+	threads, sources, _ := buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeContext, contextLines: 2, tabWidth: 8,
+		roots: []string{allowedDir},
+	})
+	frames := threads["0"].Stacks
+	if sources[frames[0].SourceCodeID].Text == "" {
+		t.Error("allowed root produced no source text")
+	}
+	if got := sources[frames[1].SourceCodeID].Text; got != "" {
+		t.Errorf("file outside SourceRoots was read: %q", got)
+	}
+}
+
+func TestSourceBudgets(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.go")
+	content := strings.Repeat("padding line\n", 100)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stack := "goroutine 1 [running]:\n" +
+		"main.a()\n" +
+		"\t" + path + ":50 +0x1\n"
+
+	// Per-file budget smaller than the file: degrade to path-only.
+	_, sources, _ := buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeContext, contextLines: 3, tabWidth: 8,
+		maxFileBytes: 64,
+	})
+	for _, sc := range sources {
+		if sc.Text != "" {
+			t.Errorf("per-file budget ignored: %d bytes embedded", len(sc.Text))
+		}
+	}
+
+	// Total budget of 1 byte: snippet cannot be embedded.
+	_, sources, _ = buildThreads([]byte(stack), sourceOptions{
+		mode: SourceCodeContext, contextLines: 3, tabWidth: 8,
+		maxTotal: 1,
+	})
+	for _, sc := range sources {
+		if sc.Text != "" {
+			t.Errorf("total source budget ignored: %d bytes embedded", len(sc.Text))
+		}
+	}
+}
+
+func TestIsSDKFrameBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"github.com/backtrace-labs/backtrace-go.Report", true},
+		{"github.com/backtrace-labs/backtrace-go", true},
+		{"github.com/backtrace-labs/backtrace-go/bthttp.(*Handler).Handle", true},
+		{"github.com/backtrace-labs/backtrace-go-fork.Report", false},
+		{"github.com/backtrace-labs/backtrace-gopher.Report", false},
+		{"main.main", false},
+	}
+	for _, c := range cases {
+		if got := isSDKFrame(c.name); got != c.want {
+			t.Errorf("isSDKFrame(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
 func TestSplitQualifiedFunction(t *testing.T) {
 	cases := []struct{ in, lib, fn string }{
 		{"main.main()", "main", "main"},

--- a/tracer.go
+++ b/tracer.go
@@ -4,6 +4,7 @@ package bt
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +27,14 @@ type pipes struct {
 	stderr io.Writer
 }
 
+const (
+	defaultPutTimeout             = 30 * time.Second
+	defaultMaxSnapshotBytes int64 = 1 << 30
+	defaultTraceTimeout           = 120 * time.Second
+)
+
+// uploader is the connection information and options used during Put
+// operations.
 type uploader struct {
 	endpoint string
 	options  PutOptions
@@ -69,6 +78,10 @@ type BTTracer struct {
 
 	// Default trace options to use if none are specified to bt.Trace().
 	defaultTraceOptions TraceOptions
+
+	// Protects the uploader configuration: traces are documented
+	// goroutine-safe and may upload concurrently with ConfigurePut.
+	putMu sync.RWMutex
 
 	// The connection information and options used during Put operations.
 	put uploader
@@ -159,7 +172,7 @@ func New(options NewOptions) *BTTracer {
 			Faulted:           true,
 			CallerOnly:        false,
 			ErrClassification: true,
-			Timeout:           time.Second * 120}}
+			Timeout:           defaultTraceTimeout}}
 }
 
 const (
@@ -167,92 +180,132 @@ const (
 	defaultCoronerPort   = "6098"
 )
 
-type PutOptions struct {
-	// If set to true, tracer results (i.e. generated snapshot files)
-	// will be unlinked from the filesystem after successful puts.
-	Unlink bool
-
-	// The http.Client to use for uploading. The default will be used
-	// if left unspecified.
-	Client http.Client
-
-	// If set to true, tracer results will be uploaded after each
-	// successful Trace request.
-	OnTrace bool
-}
-
-// Configures the uploading of a generated snapshot file to a remote Backtrace
-// coronerd object store.
-//
-// Uploads use simple one-shot semantics and won't retry on failures. For
-// more robust snapshot uploading and directory monitoring, consider using
-// coroner daemon, as described at
-// https://documentation.backtrace.io/snapshot/#daemon.
-//
-// endpoint: The URL of the server. It must be a valid HTTP endpoint as
-// according to url.Parse() (which is based on RFC 3986). The default scheme
-// and port are https and 6098, respectively, and are used if left unspecified.
-//
-// token: The hash associated with the coronerd project to which this
-// application belongs; see
-// https://documentation.backtrace.io/coronerd_setup/#authentication-tokens
-// for more details.
-//
-// options: Modifies behavior of the Put action; see PutOptions documentation
-// for more details.
-func (t *BTTracer) ConfigurePut(endpoint, token string, options PutOptions) error {
+// buildPutURL validates the upload endpoint strictly and assembles the
+// final URL. Only absolute http(s) URLs without userinfo, fragment, or
+// opaque form are accepted; a missing scheme or port receives the coronerd
+// defaults (IPv6-safe).
+func buildPutURL(endpoint, token string) (string, error) {
 	if endpoint == "" {
-		return errors.New("endpoint must be non-empty")
+		return "", errors.New("endpoint must be non-empty")
 	}
 	if token == "" {
-		return errors.New("token must be non-empty")
+		return "", errors.New("token must be non-empty")
 	}
 
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return err
+		// Do not wrap err: *url.Error quotes the raw URL, and net/url
+		// inner errors can embed quoted input fragments too. The
+		// endpoint should not carry credentials (the token is a
+		// separate argument), but redact defensively anyway.
+		msg := "unparsable URL"
+		var ue *url.Error
+		if errors.As(err, &ue) && ue.Err != nil {
+			if inner := ue.Err.Error(); !strings.Contains(inner, `"`) {
+				msg = inner
+			}
+		}
+		return "", fmt.Errorf("invalid endpoint (%s): %s", msg, redactURL(endpoint))
 	}
 
 	// Endpoints without the scheme prefix (or at the very least a '//`
 	// prefix) are interpreted as remote server paths. Handle the
-	// (unlikely) case of an unspecified scheme. We won't allow other
-	// cases, like a port specified without a scheme, though, as per
-	// RFC 3986.
-	if u.Host == "" {
-		if u.Path == "" {
-			return errors.New("invalid URL specification: host " +
-				"or path must be non-empty")
+	// (unlikely) case of an unspecified scheme — but only for bare
+	// hosts: a path component in the shifted host would silently move
+	// the upload target.
+	if u.Host == "" && u.Scheme == "" && u.Opaque == "" && u.Path != "" {
+		host := strings.TrimSuffix(u.Path, "/")
+		if strings.Contains(host, "/") {
+			return "", errors.New("endpoint must be an absolute HTTP(S) URL " +
+				"or a bare host, got a scheme-less path")
 		}
-
-		u.Host = u.Path
+		u.Host = host
 		u.Path = ""
 	}
-
 	if u.Scheme == "" {
 		u.Scheme = defaultCoronerScheme
 	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("unsupported endpoint scheme %q", u.Scheme)
+	}
+	if u.Host == "" || u.User != nil || u.Fragment != "" || u.Opaque != "" {
+		return "", errors.New("endpoint must be an absolute HTTP(S) URL " +
+			"without userinfo or fragment")
+	}
 
-	// Apply the default port IPv6-safely: Hostname() strips any
-	// brackets and JoinHostPort restores them as needed.
-	if _, _, portErr := net.SplitHostPort(u.Host); portErr != nil {
+	// Apply the default port IPv6-safely: Hostname() strips any brackets
+	// and JoinHostPort restores them as needed. Detect the missing-port
+	// case structurally and range-check explicit ports.
+	if host, port, portErr := net.SplitHostPort(u.Host); portErr != nil {
+		var addrErr *net.AddrError
+		if !errors.As(portErr, &addrErr) || !strings.Contains(addrErr.Err, "missing port") {
+			return "", fmt.Errorf("invalid endpoint host/port: %w", portErr)
+		}
 		u.Host = net.JoinHostPort(u.Hostname(), defaultCoronerPort)
+	} else {
+		if n, convErr := strconv.Atoi(port); convErr != nil || n < 1 || n > 65535 {
+			return "", fmt.Errorf("invalid endpoint port %q", port)
+		}
+		_ = host
 	}
 
 	u.Path = "post"
+	u.RawPath = ""
 	u.RawQuery = url.Values{"token": {token}}.Encode()
+	return u.String(), nil
+}
 
-	t.put.endpoint = u.String()
-	t.put.options = options
+// ConfigurePut configures the uploading of a generated snapshot file to a
+// remote Backtrace coronerd object store.
+//
+// Uploads use simple one-shot semantics and won't retry on failures. For
+// more robust snapshot uploading and directory monitoring, consider using
+// the coroner daemon.
+//
+// endpoint: the URL of the server; a valid HTTP(S) endpoint per url.Parse.
+// The default scheme and port are https and 6098, used if left unspecified.
+//
+// token: the hash associated with the coronerd project to which this
+// application belongs.
+//
+// options: modifies behavior of the Put action; see PutOptions.
+func (t *BTTracer) ConfigurePut(endpoint, token string, options PutOptions) error {
+	putURL, err := buildPutURL(endpoint, token)
+	if err != nil {
+		return err
+	}
+	if options.Timeout < 0 {
+		return errors.New("upload timeout must be positive")
+	}
+	if options.Timeout == 0 {
+		options.Timeout = defaultPutTimeout
+	}
+	if options.MaxSnapshotBytes < 0 {
+		return errors.New("snapshot size limit must be positive")
+	}
+	if options.MaxSnapshotBytes == 0 {
+		options.MaxSnapshotBytes = defaultMaxSnapshotBytes
+	}
+	if options.HTTPClient == nil {
+		options.HTTPClient = &options.Client
+	}
 
+	t.putMu.Lock()
+	t.put = uploader{endpoint: putURL, options: options}
+	t.putMu.Unlock()
+
+	// Diagnostics carry the redacted URL only: the query embeds the token.
 	t.Logf(LogDebug, "Put enabled (endpoint: %s, unlink: %v)\n",
-		t.put.endpoint,
-		t.put.options.Unlink)
+		redactURL(putURL), options.Unlink)
 
 	return nil
 }
 
 // See bt.Tracer.PutOnTrace().
 func (t *BTTracer) PutOnTrace() bool {
+	t.putMu.RLock()
+	defer t.putMu.RUnlock()
+
 	return t.put.options.OnTrace
 }
 
@@ -307,21 +360,50 @@ func putDirWalk(t *BTTracer) filepath.WalkFunc {
 func (t *BTTracer) putSnapshotFile(path string) error {
 	t.Logf(LogDebug, "Attempting to upload snapshot %s...\n", path)
 
+	t.putMu.RLock()
+	u := t.put
+	t.putMu.RUnlock()
+	if u.endpoint == "" || u.options.HTTPClient == nil {
+		return errors.New("snapshot upload is not configured")
+	}
+
 	body, err := os.Open(path)
 	if err != nil {
 		return err
 	}
 	defer body.Close()
 
-	// The file is automatically closed by the Post request after
-	// completion.
-
-	resp, err := t.put.options.Client.Post(
-		t.put.endpoint,
-		"application/octet-stream",
-		body)
+	// Snapshot files must be bounded regular files: FIFOs or devices
+	// would block or stream unbounded data.
+	info, err := body.Stat()
 	if err != nil {
 		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("snapshot is not a regular file")
+	}
+	if info.Size() > u.options.MaxSnapshotBytes {
+		return fmt.Errorf("snapshot exceeds %d-byte limit", u.options.MaxSnapshotBytes)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), u.options.Timeout)
+	defer cancel()
+	// Bound the body at read time too (the file may grow after stat) and
+	// declare the length so the request is not chunked-unbounded.
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.endpoint,
+		io.LimitReader(body, info.Size()))
+	if err != nil {
+		return fmt.Errorf("building upload request for %s: %s",
+			redactURL(u.endpoint), sanitizeHTTPError(err, u.endpoint))
+	}
+	req.ContentLength = info.Size()
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := u.options.HTTPClient.Do(req)
+	if err != nil {
+		// Never surface an error retaining the credential-bearing URL.
+		return fmt.Errorf("upload to %s failed: %s",
+			redactURL(u.endpoint), sanitizeHTTPError(err, u.endpoint))
 	}
 	defer func() {
 		// Drain (bounded) so the keep-alive connection can be reused
@@ -331,10 +413,10 @@ func (t *BTTracer) putSnapshotFile(path string) error {
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("failed to upload: %s", resp.Status)
+		return fmt.Errorf("upload to %s failed: %s", redactURL(u.endpoint), resp.Status)
 	}
 
-	if t.put.options.Unlink {
+	if u.options.Unlink {
 		t.Logf(LogDebug, "Unlinking snapshot...\n")
 
 		if err := os.Remove(path); err != nil {
@@ -483,9 +565,29 @@ func (t *BTTracer) ClearOptions() {
 	t.options = nil
 }
 
-// See bt.Tracer.DefaultTraceOptions().
+// See bt.Tracer.DefaultTraceOptions(). Returns a pointer to a COPY: mutate
+// defaults through SetDefaultTraceOptions, not through the returned value.
 func (t *BTTracer) DefaultTraceOptions() *TraceOptions {
-	return &t.defaultTraceOptions
+	t.m.RLock()
+	defer t.m.RUnlock()
+
+	opts := t.defaultTraceOptions
+	return &opts
+}
+
+// SetDefaultTraceOptions replaces the defaults used by bt.Trace when no
+// per-call options are supplied. A zero Timeout keeps the built-in default
+// (a zero default would make every Trace time out instantly); use a
+// negative Timeout to disable the deadline.
+func (t *BTTracer) SetDefaultTraceOptions(opts TraceOptions) {
+	if opts.Timeout == 0 {
+		opts.Timeout = defaultTraceTimeout
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	t.defaultTraceOptions = opts
 }
 
 // See bt.Tracer.Finalize().
@@ -516,7 +618,9 @@ func (t *BTTracer) Logf(level LogPriority, format string, v ...interface{}) {
 
 	if logger != nil {
 		// Called outside any BTTracer lock: format arguments may
-		// re-enter the tracer (e.g. %s on the tracer itself).
+		// re-enter the tracer (e.g. %s on the tracer itself). A
+		// panicking logger is contained.
+		defer func() { _ = recover() }()
 		logger.Logf(level, format, v...)
 	}
 }

--- a/tracer_darwin_stub.go
+++ b/tracer_darwin_stub.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -99,22 +98,10 @@ func New(options NewOptions) *BTTracer {
 	}
 }
 
-type PutOptions struct {
-	// If set to true, tracer results (i.e. generated snapshot files)
-	// will be unlinked from the filesystem after successful puts.
-	Unlink bool
-
-	// The http.Client to use for uploading. The default will be used
-	// if left unspecified.
-	Client http.Client
-
-	// If set to true, tracer results will be uploaded after each
-	// successful Trace request.
-	OnTrace bool
-}
-
+// ConfigurePut is unsupported on macOS; the error wraps
+// ErrUnsupportedPlatform so callers never mistake the no-op for success.
 func (t *BTTracer) ConfigurePut(endpoint, token string, options PutOptions) error {
-	return nil
+	return fmt.Errorf("%w: snapshot upload", ErrUnsupportedPlatform)
 }
 
 // See bt.Tracer.PutOnTrace().
@@ -122,14 +109,14 @@ func (t *BTTracer) PutOnTrace() bool {
 	return t.put.options.OnTrace
 }
 
-// See bt.Tracer.Put().
+// Put is unsupported on macOS.
 func (t *BTTracer) Put(snapshot []byte) error {
-	return nil
+	return fmt.Errorf("%w: snapshot upload", ErrUnsupportedPlatform)
 }
 
-// Synchronously uploads snapshots contained in the specified directory.
+// PutDir is unsupported on macOS.
 func (t *BTTracer) PutDir(path string) error {
-	return nil
+	return fmt.Errorf("%w: snapshot directory upload", ErrUnsupportedPlatform)
 }
 
 //nolint:all
@@ -146,9 +133,9 @@ func (t *BTTracer) putSnapshotFile(path string) error {
 func (t *BTTracer) SetTracerPath(path string) {
 }
 
-// Sets the output path for generated snapshots.
+// SetOutputPath is unsupported on macOS.
 func (t *BTTracer) SetOutputPath(path string, perm os.FileMode) error {
-	return nil
+	return fmt.Errorf("%w: tracer output", ErrUnsupportedPlatform)
 }
 
 // Sets the input and output pipes for the tracer.
@@ -204,9 +191,27 @@ func (t *BTTracer) Options() []string {
 func (t *BTTracer) ClearOptions() {
 }
 
-// See bt.Tracer.DefaultTraceOptions().
+// See bt.Tracer.DefaultTraceOptions(). Returns a pointer to a COPY; use
+// SetDefaultTraceOptions to change the defaults.
 func (t *BTTracer) DefaultTraceOptions() *TraceOptions {
-	return &t.defaultTraceOptions
+	t.m.RLock()
+	defer t.m.RUnlock()
+
+	opts := t.defaultTraceOptions
+	return &opts
+}
+
+// SetDefaultTraceOptions replaces the defaults used by bt.Trace when no
+// per-call options are supplied. A zero Timeout keeps the built-in default.
+func (t *BTTracer) SetDefaultTraceOptions(opts TraceOptions) {
+	if opts.Timeout == 0 {
+		opts.Timeout = 120 * time.Second
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	t.defaultTraceOptions = opts
 }
 
 // See bt.Tracer.Finalize().

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -5,9 +5,15 @@ package bt
 import (
 	"io"
 	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestConfigurePutURLForms(t *testing.T) {
@@ -50,6 +56,136 @@ func TestConfigurePutURLForms(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildPutURLRejections(t *testing.T) {
+	rejected := []struct{ name, endpoint string }{
+		{"userinfo", "https://user:pw@host"},
+		{"fragment", "https://host/x#frag"},
+		{"non-http scheme", "ftp://host"},
+		{"opaque", "mailto:x@y"},
+		{"out-of-range port", "https://host:99999"},
+		{"non-numeric port", "https://host:abc"},
+	}
+	for _, c := range rejected {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := buildPutURL(c.endpoint, "tok"); err == nil {
+				t.Errorf("buildPutURL(%q) accepted", c.endpoint)
+			}
+		})
+	}
+
+	// The parse-failure error must not leak the raw endpoint verbatim.
+	if _, err := buildPutURL("https://host/x\x7f?token=SECRETLEAK", "tok"); err == nil {
+		t.Error("control-character endpoint accepted")
+	} else if strings.Contains(err.Error(), "SECRETLEAK") {
+		t.Errorf("raw endpoint leaked through parse error: %v", err)
+	}
+}
+
+func TestConfigurePutOptionValidation(t *testing.T) {
+	tr := New(NewOptions{})
+	if err := tr.ConfigurePut("https://host", "tok", PutOptions{Timeout: -time.Second}); err == nil {
+		t.Error("negative upload timeout accepted")
+	}
+	if err := tr.ConfigurePut("https://host", "tok", PutOptions{MaxSnapshotBytes: -1}); err == nil {
+		t.Error("negative snapshot size limit accepted")
+	}
+}
+
+// TestDefaultTraceOptionsCopySemantics pins the race fix: the returned
+// pointer is a copy, and SetDefaultTraceOptions is the mutation path.
+func TestDefaultTraceOptionsCopySemantics(t *testing.T) {
+	tr := New(NewOptions{})
+	opts := tr.DefaultTraceOptions()
+	opts.Timeout = time.Nanosecond // must NOT affect the tracer's defaults
+
+	if got := tr.DefaultTraceOptions().Timeout; got != 120*time.Second {
+		t.Errorf("defaults mutated through returned pointer: Timeout = %v", got)
+	}
+
+	tr.SetDefaultTraceOptions(TraceOptions{Timeout: 7 * time.Second})
+	if got := tr.DefaultTraceOptions().Timeout; got != 7*time.Second {
+		t.Errorf("SetDefaultTraceOptions not applied: Timeout = %v", got)
+	}
+}
+
+func TestPutSnapshotFileHardening(t *testing.T) {
+	dir := t.TempDir()
+	snapshot := filepath.Join(dir, "snap.btt")
+	if err := os.WriteFile(snapshot, []byte("snapshot-bytes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("unconfigured", func(t *testing.T) {
+		tr := New(NewOptions{})
+		if err := tr.putSnapshotFile(snapshot); err == nil ||
+			!strings.Contains(err.Error(), "not configured") {
+			t.Errorf("err = %v, want not-configured error", err)
+		}
+	})
+
+	t.Run("non-regular file rejected", func(t *testing.T) {
+		fifo := filepath.Join(dir, "snap.fifo")
+		if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+			t.Skipf("mkfifo unavailable: %v", err)
+		}
+		// Keep the FIFO openable without blocking: open the write end.
+		w, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if err == nil {
+			defer w.Close()
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("non-regular file reached the server")
+		}))
+		defer srv.Close()
+		tr := New(NewOptions{})
+		if err := tr.ConfigurePut(srv.URL, "tok", PutOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := tr.putSnapshotFile(fifo); err == nil ||
+			!strings.Contains(err.Error(), "regular file") {
+			t.Errorf("err = %v, want regular-file rejection", err)
+		}
+	})
+
+	t.Run("size cap enforced", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("oversized snapshot reached the server")
+		}))
+		defer srv.Close()
+		tr := New(NewOptions{})
+		if err := tr.ConfigurePut(srv.URL, "tok", PutOptions{MaxSnapshotBytes: 4}); err != nil {
+			t.Fatal(err)
+		}
+		if err := tr.putSnapshotFile(snapshot); err == nil ||
+			!strings.Contains(err.Error(), "limit") {
+			t.Errorf("err = %v, want size-limit rejection", err)
+		}
+	})
+
+	t.Run("success with bounded body and token-safe endpoint", func(t *testing.T) {
+		var gotLen int64
+		var gotToken string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			gotLen = int64(len(body))
+			gotToken = r.URL.Query().Get("token")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		tr := New(NewOptions{})
+		if err := tr.ConfigurePut(srv.URL, "tok", PutOptions{}); err != nil {
+			t.Fatal(err)
+		}
+		if err := tr.putSnapshotFile(snapshot); err != nil {
+			t.Fatalf("putSnapshotFile: %v", err)
+		}
+		if gotLen != int64(len("snapshot-bytes")) || gotToken != "tok" {
+			t.Errorf("upload = %d bytes, token %q", gotLen, gotToken)
+		}
+	})
 }
 
 // TestTracerLoggerConcurrency locks in the fix for the recursive-RLock

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -126,16 +125,8 @@ func TestPutSnapshotFileHardening(t *testing.T) {
 	})
 
 	t.Run("non-regular file rejected", func(t *testing.T) {
-		fifo := filepath.Join(dir, "snap.fifo")
-		if err := syscall.Mkfifo(fifo, 0o644); err != nil {
-			t.Skipf("mkfifo unavailable: %v", err)
-		}
-		// Keep the FIFO openable without blocking: open the write end.
-		w, err := os.OpenFile(fifo, os.O_WRONLY|syscall.O_NONBLOCK, 0)
-		if err == nil {
-			defer w.Close()
-		}
-
+		// A device file opens instantly (unlike a FIFO, whose blocking
+		// read-end open would hang the test) and is not regular.
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			t.Error("non-regular file reached the server")
 		}))
@@ -144,7 +135,7 @@ func TestPutSnapshotFileHardening(t *testing.T) {
 		if err := tr.ConfigurePut(srv.URL, "tok", PutOptions{}); err != nil {
 			t.Fatal(err)
 		}
-		if err := tr.putSnapshotFile(fifo); err == nil ||
+		if err := tr.putSnapshotFile(os.DevNull); err == nil ||
 			!strings.Contains(err.Error(), "regular file") {
 			t.Errorf("err = %v, want regular-file rejection", err)
 		}

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package bt
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,11 +32,14 @@ const rateLimitFallback = time.Minute
 const rateLimitMaxPause = 5 * time.Minute
 
 // httpTransport delivers serialized reports over HTTP. It is safe for
-// concurrent use, applies the configured timeout, verifies response status,
-// honors 429 Retry-After, and drains response bodies so connections are
-// reused.
+// concurrent use, applies the configured deadline through an SDK-owned
+// request context (independent of any custom http.Client), verifies
+// response status, honors 429 Retry-After, drains response bodies so
+// connections are reused, and never lets a credential-bearing URL escape
+// into an error or log line.
 type httpTransport struct {
-	client *http.Client
+	client  *http.Client
+	timeout time.Duration
 
 	mu         sync.Mutex
 	pauseUntil time.Time
@@ -43,9 +47,15 @@ type httpTransport struct {
 
 func newHTTPTransport(client *http.Client, timeout time.Duration) *httpTransport {
 	if client == nil {
-		client = &http.Client{Timeout: timeout}
+		client = &http.Client{}
 	}
-	return &httpTransport{client: client}
+	return &httpTransport{client: client, timeout: timeout}
+}
+
+func (t *httpTransport) closeIdleConnections() {
+	if t != nil && t.client != nil {
+		t.client.CloseIdleConnections()
+	}
 }
 
 // rateLimited reports whether submissions are currently paused.
@@ -61,80 +71,134 @@ func (t *httpTransport) pause(d time.Duration) {
 	t.pauseUntil = time.Now().Add(d)
 }
 
-// maxAttachmentSize caps individual attachment uploads; larger files are
-// skipped with a diagnostic.
-const maxAttachmentSize = 10 << 20 // 10 MiB
-
 // inlinePart is an in-memory attachment (e.g. the bt-breadcrumbs-0 file).
 type inlinePart struct {
 	name string
 	data []byte
 }
 
-// send POSTs body to url. Attachments, when present, switch the request to
-// the documented multipart form ("upload_file" part for the report JSON,
-// "attachment_<name>" parts for files). A non-2xx response is an error; a
-// 429 additionally pauses future sends until the server's Retry-After
-// deadline.
-func (t *httpTransport) send(url string, body []byte, attachments []string, inline []inlinePart, d diag) error {
+// send POSTs body to url under an SDK-owned deadline derived from parent.
+// Attachments, when present, switch the request to the documented multipart
+// form ("upload_file" part for the report JSON, "attachment_<name>" parts
+// for files). It returns the drop reason alongside any error.
+func (t *httpTransport) send(
+	parent context.Context,
+	url string,
+	body []byte,
+	attachments []string,
+	inline []inlinePart,
+	limits multipartLimits,
+	d diag,
+) (dropReason, error) {
 	if t.rateLimited() {
-		return errRateLimited
+		return dropRateLimit, errRateLimited
 	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, t.timeout)
+	defer cancel()
 
 	var (
 		reqBody     io.Reader = bytes.NewReader(body)
 		contentType           = "application/json"
 	)
 	if len(attachments) > 0 || len(inline) > 0 {
-		multipartBody, multipartType, err := buildMultipart(body, attachments, inline, d)
+		multipartBody, multipartType, err := buildMultipart(body, attachments, inline, limits, d)
 		if err != nil {
-			return fmt.Errorf("bt: building multipart request: %w", err)
+			return dropSerialization, fmt.Errorf("bt: building multipart request: %w", err)
 		}
 		reqBody, contentType = multipartBody, multipartType
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, reqBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reqBody)
 	if err != nil {
-		return fmt.Errorf("bt: building request: %w", err)
+		return dropSerialization, fmt.Errorf("bt: building request for %s: %s",
+			redactURL(url), sanitizeHTTPError(err, url))
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("User-Agent", "backtrace-go/"+Version)
 
 	resp, err := t.client.Do(req)
 	if err != nil {
-		// *url.Error embeds the full URL (token included); scrub it
-		// before the error reaches any log.
-		var ue *neturl.Error
-		if errors.As(err, &ue) {
-			ue.URL = redactURL(ue.URL)
-		}
-		return fmt.Errorf("bt: sending report: %w", err)
+		// Never return an error that retains a credential-bearing URL.
+		return dropNetwork, fmt.Errorf("bt: sending report to %s: %s",
+			redactURL(url), sanitizeHTTPError(err, url))
 	}
 	defer func() {
-		// Drain so the keep-alive connection can be reused.
+		// Drain (bounded) so the keep-alive connection can be reused.
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
 		_ = resp.Body.Close()
 	}()
 
 	switch {
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		return nil
+		return 0, nil
 	case resp.StatusCode == http.StatusTooManyRequests:
-		d := retryAfter(resp)
-		t.pause(d)
-		return fmt.Errorf("bt: server rate limit (429), pausing submissions for %s", d)
+		pause := retryAfter(resp)
+		t.pause(pause)
+		return dropRateLimit, fmt.Errorf("bt: server rate limit (429), pausing submissions for %s", pause)
 	default:
-		return fmt.Errorf("bt: server rejected report: %s", resp.Status)
+		return dropServerReject, fmt.Errorf("bt: server rejected report: %s", resp.Status)
 	}
+}
+
+// sanitizeHTTPError renders err with every occurrence of the raw URL or its
+// embedded credentials replaced. Returns a string (not an error) so callers
+// cannot accidentally re-wrap the original.
+func sanitizeHTTPError(err error, rawURL string) string {
+	if err == nil {
+		return ""
+	}
+	text := err.Error()
+	if rawURL != "" {
+		text = strings.ReplaceAll(text, rawURL, redactURL(rawURL))
+	}
+	if u, parseErr := neturl.Parse(rawURL); parseErr == nil {
+		if token := u.Query().Get("token"); token != "" {
+			text = strings.ReplaceAll(text, token, "REDACTED")
+		}
+		segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if pathEmbedsToken(u.Hostname(), segments) {
+			text = strings.ReplaceAll(text, segments[1], "REDACTED")
+		}
+	}
+	return text
+}
+
+// maxMultipartNameLength bounds sanitized attachment part names.
+const maxMultipartNameLength = 255
+
+// safeMultipartName reduces an attachment path to a conservative printable
+// basename for use in multipart part names and filenames.
+func safeMultipartName(path string) string {
+	name := filepath.Base(path)
+	name = strings.Map(func(r rune) rune {
+		switch {
+		case r == '\r' || r == '\n' || r == 0 || r == '"' || r == '\\':
+			return '_'
+		case r < 0x20 || r == 0x7f:
+			return '_'
+		default:
+			return r
+		}
+	}, name)
+	if name == "" || name == "." || name == ".." || name == "/" || name == `\` {
+		return "attachment"
+	}
+	if len(name) > maxMultipartNameLength {
+		name = name[len(name)-maxMultipartNameLength:]
+	}
+	return name
 }
 
 // buildMultipart assembles the multipart body documented for Backtrace
 // submissions: the report JSON in an "upload_file" part plus one
-// "attachment_<basename>" part per readable attachment. Unreadable,
-// non-regular, or oversized files are skipped, never failing the report
-// itself. The size cap is enforced at read time (a file may grow between
-// stat and copy).
-func buildMultipart(body []byte, attachments []string, inline []inlinePart, d diag) (io.Reader, string, error) {
+// "attachment_<basename>" part per admitted attachment. Unreadable,
+// non-regular, oversized, or over-budget files — and files that fail while
+// being read — are skipped, never failing the report itself. Size caps are
+// enforced at read time (a file may grow between stat and copy).
+func buildMultipart(body []byte, attachments []string, inline []inlinePart, limits multipartLimits, d diag) (io.Reader, string, error) {
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 
@@ -158,30 +222,54 @@ func buildMultipart(body []byte, attachments []string, inline []inlinePart, d di
 		}
 	}
 
+	var (
+		count      int
+		totalBytes int64
+	)
 	for _, path := range attachments {
-		info, err := os.Stat(path)
-		if err != nil {
-			d.logf("attachment %q skipped: %v", path, err)
+		if limits.maxAttachments < 0 {
+			d.logf("attachment %q skipped: attachments disabled (MaxAttachments < 0)", path)
 			continue
 		}
-		// FIFOs and devices would block or read unbounded data.
-		if !info.Mode().IsRegular() {
-			d.logf("attachment %q skipped: not a regular file", path)
+		if count >= limits.maxAttachments {
+			d.logf("attachment %q skipped: attachment count limit (%d) reached",
+				path, limits.maxAttachments)
 			continue
 		}
-		if info.Size() > maxAttachmentSize {
-			d.logf("attachment %q skipped: %d bytes exceeds the %d byte limit",
-				path, info.Size(), maxAttachmentSize)
+		remaining := limits.maxTotalBytes - totalBytes
+		if remaining <= 0 {
+			d.logf("attachment %q skipped: aggregate attachment budget (%d bytes) exhausted",
+				path, limits.maxTotalBytes)
 			continue
 		}
+		perFile := limits.maxAttachmentBytes
+		if perFile > remaining {
+			perFile = remaining
+		}
+
 		file, err := os.Open(path)
 		if err != nil {
 			d.logf("attachment %q skipped: %v", path, err)
 			continue
 		}
-		// Attachments from different directories may share a
-		// basename; uniquify so no part overwrites another.
-		name := filepath.Base(path)
+		// Stat the opened handle (not the path) so a file swapped
+		// between stat and open cannot bypass the checks.
+		info, err := file.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			file.Close()
+			d.logf("attachment %q skipped: not a readable regular file", path)
+			continue
+		}
+		if info.Size() > perFile {
+			file.Close()
+			d.logf("attachment %q skipped: %d bytes exceeds the %d-byte budget",
+				path, info.Size(), perFile)
+			continue
+		}
+
+		// Attachments from different directories may share a basename;
+		// uniquify so no part overwrites another.
+		name := safeMultipartName(path)
 		if used[name] {
 			ext := filepath.Ext(name)
 			stem := strings.TrimSuffix(name, ext)
@@ -195,26 +283,31 @@ func buildMultipart(body []byte, attachments []string, inline []inlinePart, d di
 		}
 		used[name] = true
 
-		// Remember the buffer position so an over-limit file can be
-		// rolled back cleanly (part boundaries are only written by
-		// CreateFormFile/Close, so truncating to the mark removes the
-		// whole part).
+		// Remember the buffer position so a failed or over-limit read
+		// can be rolled back cleanly (part boundaries are only written
+		// by CreateFormFile/Close, so truncating removes the part).
 		mark := buf.Len()
 		part, err := w.CreateFormFile("attachment_"+name, name)
 		var copied int64
 		if err == nil {
-			copied, err = io.Copy(part, io.LimitReader(file, maxAttachmentSize+1))
+			copied, err = io.Copy(part, io.LimitReader(file, perFile+1))
 		}
 		file.Close()
 		if err != nil {
-			return nil, "", err
-		}
-		if copied > maxAttachmentSize {
 			buf.Truncate(mark)
 			delete(used, name)
-			d.logf("attachment %q skipped: grew beyond the %d byte limit while reading",
-				path, maxAttachmentSize)
+			d.logf("attachment %q skipped: read failed: %v", path, err)
+			continue
 		}
+		if copied > perFile {
+			buf.Truncate(mark)
+			delete(used, name)
+			d.logf("attachment %q skipped: grew beyond the %d-byte budget while reading",
+				path, perFile)
+			continue
+		}
+		count++
+		totalBytes += copied
 	}
 
 	if err := w.Close(); err != nil {
@@ -223,13 +316,16 @@ func buildMultipart(body []byte, attachments []string, inline []inlinePart, d di
 	return &buf, w.FormDataContentType(), nil
 }
 
-// redactURL hides the submission token in diagnostics output, both in the
-// ?token= query form and in the submit.backtrace.io/{universe}/{token}/{fmt}
+// redactURL hides credentials in diagnostics output: URL userinfo, the
+// ?token= query form, and the submit-style {universe}/{token}/{format}
 // path form.
 func redactURL(u string) string {
 	parsed, err := neturl.Parse(u)
 	if err != nil {
-		return u
+		return "[REDACTED URL]"
+	}
+	if parsed.User != nil {
+		parsed.User = neturl.User("REDACTED")
 	}
 	q := parsed.Query()
 	if q.Get("token") != "" {
@@ -255,7 +351,7 @@ var hexTokenPattern = regexp.MustCompile(`^[0-9a-fA-F]{32,}$`)
 // path has the {universe}/{token}[/{format}] shape (known format suffix or
 // a hex token). Plain API paths like /api/post never match.
 func pathEmbedsToken(host string, segments []string) bool {
-	if len(segments) < 2 || len(segments) > 3 {
+	if len(segments) < 2 || len(segments) > 3 || segments[1] == "" {
 		return false
 	}
 	if strings.EqualFold(host, "submit.backtrace.io") {

--- a/transport.go
+++ b/transport.go
@@ -173,6 +173,11 @@ const maxMultipartNameLength = 255
 // basename for use in multipart part names and filenames.
 func safeMultipartName(path string) string {
 	name := filepath.Base(path)
+	// Degenerate basenames first: on Windows, Base("/") is `\`, which the
+	// character mapping below would otherwise turn into "_".
+	if name == "" || name == "." || name == ".." || name == "/" || name == `\` {
+		return "attachment"
+	}
 	name = strings.Map(func(r rune) rune {
 		switch {
 		case r == '\r' || r == '\n' || r == 0 || r == '"' || r == '\\':
@@ -183,7 +188,7 @@ func safeMultipartName(path string) string {
 			return r
 		}
 	}, name)
-	if name == "" || name == "." || name == ".." || name == "/" || name == `\` {
+	if name == "" {
 		return "attachment"
 	}
 	if len(name) > maxMultipartNameLength {

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,6 +1,8 @@
 package bt
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -52,8 +54,10 @@ func TestTransportPause(t *testing.T) {
 	if !tr.rateLimited() {
 		t.Error("pause not applied")
 	}
-	if err := tr.send("http://127.0.0.1:1/unused", []byte("{}"), nil, nil, diag{}); err != errRateLimited {
-		t.Errorf("send while paused = %v, want errRateLimited", err)
+	reason, err := tr.send(context.Background(), "http://127.0.0.1:1/unused",
+		[]byte("{}"), nil, nil, multipartLimits{}, diag{})
+	if err != errRateLimited || reason != dropRateLimit {
+		t.Errorf("send while paused = (%v, %v), want (dropRateLimit, errRateLimited)", reason, err)
 	}
 }
 
@@ -86,5 +90,46 @@ func TestRedactURL(t *testing.T) {
 	// Plain API paths never match the token shape.
 	if got := redactURL("https://uni.sp.backtrace.io/api/post"); got != "https://uni.sp.backtrace.io/api/post" {
 		t.Errorf("tokenless URL modified: %q", got)
+	}
+	// URL userinfo is redacted.
+	if got := redactURL("https://user:secretpw@host/x"); strings.Contains(got, "secretpw") {
+		t.Errorf("userinfo not redacted: %q", got)
+	}
+	// Unparsable input degrades to a fixed placeholder, never the raw string.
+	if got := redactURL("http://%zz\x7f"); got != "[REDACTED URL]" {
+		t.Errorf("unparsable URL leaked: %q", got)
+	}
+}
+
+func TestSanitizeHTTPError(t *testing.T) {
+	raw := "https://uni.sp.backtrace.io/post?format=json&token=supersecret"
+	err := errors.New(`Post "` + raw + `": context deadline exceeded`)
+	out := sanitizeHTTPError(err, raw)
+	if strings.Contains(out, "supersecret") {
+		t.Errorf("token leaked through sanitized error: %q", out)
+	}
+	if !strings.Contains(out, "context deadline exceeded") {
+		t.Errorf("error cause lost: %q", out)
+	}
+
+	pathRaw := "https://submit.backtrace.io/universe/secrettoken123/json"
+	pathErr := errors.New(`Post "` + pathRaw + `": connection refused`)
+	if out := sanitizeHTTPError(pathErr, pathRaw); strings.Contains(out, "secrettoken123") {
+		t.Errorf("path token leaked through sanitized error: %q", out)
+	}
+}
+
+func TestSafeMultipartName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/var/log/app.log", "app.log"},
+		{"/tmp/evil\r\nname", "evil__name"},
+		{"/tmp/quote\"back\\slash", "quote_back_slash"},
+		{"/", "attachment"},
+		{".", "attachment"},
+	}
+	for _, c := range cases {
+		if got := safeMultipartName(c.in); got != c.want {
+			t.Errorf("safeMultipartName(%q) = %q, want %q", c.in, got, c.want)
+		}
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -120,12 +120,16 @@ func TestSanitizeHTTPError(t *testing.T) {
 }
 
 func TestSafeMultipartName(t *testing.T) {
+	// Only separator-free basenames and portable paths: filepath.Base
+	// treats `\` as a separator on Windows, so embedded-backslash
+	// expectations would be platform-dependent.
 	cases := []struct{ in, want string }{
 		{"/var/log/app.log", "app.log"},
-		{"/tmp/evil\r\nname", "evil__name"},
-		{"/tmp/quote\"back\\slash", "quote_back_slash"},
+		{"evil\r\nname", "evil__name"},
+		{"quote\"file", "quote_file"},
 		{"/", "attachment"},
 		{".", "attachment"},
+		{"..", "attachment"},
 	}
 	for _, c := range cases {
 		if got := safeMultipartName(c.in); got != c.want {


### PR DESCRIPTION
An error-reporting SDK must never become the incident. 

After this change the SDK cannot crash, hang, or leak from the host application: every path that executes application code is panic-contained (including re-entrant loggers and typed-nil errors), every wait is bounded and cancellable, every payload component has a byte budget, and no credential can reach a log, error string, or report annotation.